### PR TITLE
feat: load updates from mongo instead of api.oboapp.online

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -44,7 +44,7 @@ YSM_OBOAPP_SYNC_API_KEY=YOUR_SYNC_API_KEY_HERE_CHANGE_IN_PRODUCTION
 # Max messages count before /api/updates-export returns 413 (default: 100)
 # YSM_OBOAPP_SYNC_LIMIT_MAX=100
 
-# Upstream OboApp proxy (legacy) — still used by /api/updates/sources and notifications task.
+# Upstream OboApp proxy (legacy) — still used by /api/updates/sources.
 OBOAPP_UPDATES_BASE_URL=https://api.oboapp.online/api
 OBOAPP_API_KEY=YOUR_OBOAPP_API_KEY
 

--- a/.env.example
+++ b/.env.example
@@ -31,11 +31,21 @@ NODE_ENV=development
 # Server port
 PORT=3000
 
-# Upstream OboApp base URL used for updates proxy routes.
-# Expected to point to the OboApp public v1 API base (for example: https://oboapp.online/api/v1)
-OBOAPP_UPDATES_BASE_URL=https://oboapp.online/api/v1
+# YSM OboApp MongoDB — read-only, shared with the YSM OboApp fork ingestion pipeline.
+# Start MongoDB with (run inside WSL):
+#   cd /path/to/ysm-oboapp-fork && docker compose up -d
+# Default local connection (user/pass from oboapp compose.yml):
+YSM_OBOAPP_MONGODB_URI=mongodb://oboapp:oboapp_dev@localhost:27017/oboapp?authSource=admin
+YSM_OBOAPP_MONGODB_DATABASE=oboapp
 
-# API key for OboApp public API (sent as X-Api-Key upstream)
+# Private API key for oboapp.online to fetch /api/updates-export
+YSM_OBOAPP_SYNC_API_KEY=YOUR_SYNC_API_KEY_HERE_CHANGE_IN_PRODUCTION
+
+# Max messages count before /api/updates-export returns 413 (default: 100)
+# YSM_OBOAPP_SYNC_LIMIT_MAX=100
+
+# Upstream OboApp proxy (legacy) — still used by /api/updates/sources and notifications task.
+OBOAPP_UPDATES_BASE_URL=https://api.oboapp.online/api
 OBOAPP_API_KEY=YOUR_OBOAPP_API_KEY
 
 # Inspectorat GPS API configuration

--- a/.env.production.example
+++ b/.env.production.example
@@ -18,10 +18,15 @@ PREVIEW_SECRET=CHANGE_ME_GENERATE_RANDOM_STRING_32_CHARS
 # Server URL (Update with your domain)
 NEXT_PUBLIC_SERVER_URL=https://your.sofia.bg
 
-# Upstream OboApp base URL used for updates proxy routes
-OBOAPP_UPDATES_BASE_URL=https://oboapp.online/api/v1
+# YSM OboApp MongoDB — read-only, shared with the YSM OboApp fork ingestion pipeline
+YSM_OBOAPP_MONGODB_URI=mongodb://CHANGE_ME_USER:CHANGE_ME_PASSWORD@mongo-host:27017/oboapp?authSource=admin
+YSM_OBOAPP_MONGODB_DATABASE=oboapp
 
-# API key for OboApp public API (sent as X-Api-Key upstream)
+# Private API key for oboapp.online to fetch /api/updates-export
+YSM_OBOAPP_SYNC_API_KEY=CHANGE_ME_GENERATE_RANDOM_STRING_32_CHARS
+
+# Upstream OboApp proxy — required for /api/updates/sources (legacy mobile support)
+OBOAPP_UPDATES_BASE_URL=https://api.oboapp.online/api
 OBOAPP_API_KEY=CHANGE_ME_OBOAPP_API_KEY
 
 # Node Environment

--- a/next.config.js
+++ b/next.config.js
@@ -1,6 +1,10 @@
 import { withPayload } from '@payloadcms/next/withPayload'
+import path from 'path'
+import { fileURLToPath } from 'url'
 
 import redirects from './redirects.js'
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url))
 
 const NEXT_PUBLIC_SERVER_URL = process.env.VERCEL_PROJECT_PRODUCTION_URL
   ? `https://${process.env.VERCEL_PROJECT_PRODUCTION_URL}`
@@ -26,7 +30,13 @@ const nextConfig = {
   },
   reactStrictMode: true,
   redirects,
-  output: 'standalone', // Enable for Docker deployment
+  sassOptions: {
+    includePaths: [
+      path.join(__dirname, 'node_modules/@payloadcms/ui/dist/scss'),
+      path.join(__dirname, 'node_modules/@payloadcms/ui/dist'),
+    ],
+  },
+  output: 'standalone',
   webpack: (config) => {
     // Replace chunkhash with contenthash for consistent hashing
     // https://www.reddit.com/r/nextjs/comments/1o4a0fv/deploying_payload_cms_3x_with_docker_compose/

--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
     "graphql": "^16.11.0",
     "leaflet": "^1.9.4",
     "lucide-react": "^0.561.0",
+    "mongodb": "^6.21.0",
     "next": "16.2.6",
     "next-sitemap": "^4.2.3",
     "payload": "3.84.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -111,6 +111,9 @@ importers:
       lucide-react:
         specifier: ^0.561.0
         version: 0.561.0(react@19.2.6)
+      mongodb:
+        specifier: ^6.21.0
+        version: 6.21.0(@aws-sdk/credential-providers@3.1000.0)
       next:
         specifier: 16.2.6
         version: 16.2.6(@babel/core@7.28.6)(babel-plugin-macros@3.1.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.77.4)
@@ -1384,6 +1387,9 @@ packages:
       react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
       react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
 
+  '@mongodb-js/saslprep@1.4.11':
+    resolution: {integrity: sha512-o9rAHc0IpIjuPSxRutWpE1F62x7n+4mVS4rCNHkzhIUMQcc18bb6xEq5wd2NdN0WjepIyXIppRshYI2kQDOZVA==}
+
   '@napi-rs/wasm-runtime@0.2.12':
     resolution: {integrity: sha512-ZVWUcfwY4E/yPitQJl481FjFo3K22D6qF0DuFH6Y/nbnE11GY5uguDxZMGXPQ8WQ0128MXQD7TnfHyK4oWoIJQ==}
 
@@ -2354,8 +2360,14 @@ packages:
   '@types/use-sync-external-store@0.0.6':
     resolution: {integrity: sha512-zFDAD+tlpf2r4asuHEj0XH6pY6i0g5NeAHPn+15wk3BV6JA69eERFXC1gyGThDkVa1zCyKr5jox1+2LbV/AMLg==}
 
+  '@types/webidl-conversions@7.0.3':
+    resolution: {integrity: sha512-CiJJvcRtIgzadHCYXw7dqEnMNRjhGZlYK05Mj9OyktqV8uVT8fD2BFOB7S1uwBE3Kj2Z+4UyPmFw/Ixgw/LAlA==}
+
   '@types/whatwg-mimetype@3.0.2':
     resolution: {integrity: sha512-c2AKvDT8ToxLIOUlN51gTiHXflsfIFisS4pO7pDPoKouJCESkhZnEy623gwP9laCy5lnLDAw1vAzu2vM2YLOrA==}
+
+  '@types/whatwg-url@11.0.5':
+    resolution: {integrity: sha512-coYR071JRaHa+xoEvvYqvnIHaVqaYrLPbsufM9BF63HkwI5Lgmy2QR8Q5K/lYDYo5AK82wOvSOS0UsLTpTG7uQ==}
 
   '@types/ws@8.18.1':
     resolution: {integrity: sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==}
@@ -2789,6 +2801,10 @@ packages:
 
   bson-objectid@2.0.4:
     resolution: {integrity: sha512-vgnKAUzcDoa+AeyYwXCoHyF2q6u/8H46dxu5JN+4/TZeq/Dlinn0K6GvxsCLb3LHUJl0m/TLiEK31kUwtgocMQ==}
+
+  bson@6.10.4:
+    resolution: {integrity: sha512-WIsKqkSC0ABoBJuT1LEX+2HEvNmNKKgnTAyd0fL8qzK4SH2i9NXg+t08YtdZp/V9IZ33cxe3iV4yM0qg8lMQng==}
+    engines: {node: '>=16.20.1'}
 
   buffer-from@1.1.2:
     resolution: {integrity: sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==}
@@ -4461,6 +4477,9 @@ packages:
   memoize-one@6.0.0:
     resolution: {integrity: sha512-rkpe71W0N0c0Xz6QD0eJETuWAJGnJ9afsl1srmwPrI+yBCkge5EycXXbYRyvL29zZVUWQCY7InPRCv3GDXuZNw==}
 
+  memory-pager@1.5.0:
+    resolution: {integrity: sha512-ZS4Bp4r/Zoeq6+NLJpP+0Zzm0pR8whtGPf1XExKLJBAczGMnSi3It14OiNCStjQjM6NU1okjQGSxgEZN8eBYKg==}
+
   merge-stream@2.0.0:
     resolution: {integrity: sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==}
 
@@ -4588,6 +4607,36 @@ packages:
 
   monaco-editor@0.53.0:
     resolution: {integrity: sha512-0WNThgC6CMWNXXBxTbaYYcunj08iB5rnx4/G56UOPeL9UVIUGGHA1GR0EWIh9Ebabj7NpCRawQ5b0hfN1jQmYQ==}
+
+  mongodb-connection-string-url@3.0.2:
+    resolution: {integrity: sha512-rMO7CGo/9BFwyZABcKAWL8UJwH/Kc2x0g72uhDWzG48URRax5TCIcJ7Rc3RZqffZzO/Gwff/jyKwCU9TN8gehA==}
+
+  mongodb@6.21.0:
+    resolution: {integrity: sha512-URyb/VXMjJ4da46OeSXg+puO39XH9DeQpWCslifrRn9JWugy0D+DvvBvkm2WxmHe61O/H19JM66p1z7RHVkZ6A==}
+    engines: {node: '>=16.20.1'}
+    peerDependencies:
+      '@aws-sdk/credential-providers': ^3.188.0
+      '@mongodb-js/zstd': ^1.1.0 || ^2.0.0
+      gcp-metadata: ^5.2.0
+      kerberos: ^2.0.1
+      mongodb-client-encryption: '>=6.0.0 <7'
+      snappy: ^7.3.2
+      socks: ^2.7.1
+    peerDependenciesMeta:
+      '@aws-sdk/credential-providers':
+        optional: true
+      '@mongodb-js/zstd':
+        optional: true
+      gcp-metadata:
+        optional: true
+      kerberos:
+        optional: true
+      mongodb-client-encryption:
+        optional: true
+      snappy:
+        optional: true
+      socks:
+        optional: true
 
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
@@ -5406,6 +5455,9 @@ packages:
   source-map@0.6.1:
     resolution: {integrity: sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==}
     engines: {node: '>=0.10.0'}
+
+  sparse-bitfield@3.0.3:
+    resolution: {integrity: sha512-kvzhi7vqKTfkh0PZU+2D2PIllw2ymqJKujUcyPMd9Y75Nv4nPbGJZXNhxsgdQab2BmlDct1YnfQCguEvHr7VsQ==}
 
   split2@4.2.0:
     resolution: {integrity: sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==}
@@ -7756,6 +7808,10 @@ snapshots:
       react: 19.2.6
       react-dom: 19.2.6(react@19.2.6)
 
+  '@mongodb-js/saslprep@1.4.11':
+    dependencies:
+      sparse-bitfield: 3.0.3
+
   '@napi-rs/wasm-runtime@0.2.12':
     dependencies:
       '@emnapi/core': 1.5.0
@@ -8988,7 +9044,13 @@ snapshots:
 
   '@types/use-sync-external-store@0.0.6': {}
 
+  '@types/webidl-conversions@7.0.3': {}
+
   '@types/whatwg-mimetype@3.0.2': {}
+
+  '@types/whatwg-url@11.0.5':
+    dependencies:
+      '@types/webidl-conversions': 7.0.3
 
   '@types/ws@8.18.1':
     dependencies:
@@ -9460,6 +9522,8 @@ snapshots:
       node-int64: 0.4.0
 
   bson-objectid@2.0.4: {}
+
+  bson@6.10.4: {}
 
   buffer-from@1.1.2: {}
 
@@ -11429,6 +11493,8 @@ snapshots:
 
   memoize-one@6.0.0: {}
 
+  memory-pager@1.5.0: {}
+
   merge-stream@2.0.0: {}
 
   merge2@1.4.1: {}
@@ -11636,6 +11702,19 @@ snapshots:
   monaco-editor@0.53.0:
     dependencies:
       '@types/trusted-types': 1.0.6
+
+  mongodb-connection-string-url@3.0.2:
+    dependencies:
+      '@types/whatwg-url': 11.0.5
+      whatwg-url: 14.2.0
+
+  mongodb@6.21.0(@aws-sdk/credential-providers@3.1000.0):
+    dependencies:
+      '@mongodb-js/saslprep': 1.4.11
+      bson: 6.10.4
+      mongodb-connection-string-url: 3.0.2
+    optionalDependencies:
+      '@aws-sdk/credential-providers': 3.1000.0
 
   ms@2.1.3: {}
 
@@ -12554,6 +12633,10 @@ snapshots:
   source-map@0.5.7: {}
 
   source-map@0.6.1: {}
+
+  sparse-bitfield@3.0.3:
+    dependencies:
+      memory-pager: 1.5.0
 
   split2@4.2.0: {}
 

--- a/src/endpoints/__tests__/oboProxy.test.ts
+++ b/src/endpoints/__tests__/oboProxy.test.ts
@@ -3,19 +3,388 @@ import { updatesById } from '../updatesById'
 import { updatesOpenApi } from '../updatesOpenApi'
 import { updatesSources } from '../updatesSources'
 
-describe('updates proxy endpoints (unit)', () => {
+// ─── Mock oboMongo ────────────────────────────────────────────────────────
+
+jest.mock('../../lib/oboMongo', () => ({
+  getMessagesCollection: jest.fn(),
+  getSourcesCollection: jest.fn(),
+  isMongoConfigured: jest.fn(() => true),
+  SOFIA_LOCALITY: 'bg.sofia',
+}))
+
+import { getMessagesCollection } from '../../lib/oboMongo'
+
+// ─── Helpers ──────────────────────────────────────────────────────────────
+
+function makeMessage(overrides: Record<string, unknown> = {}): Record<string, unknown> {
+  return {
+    _id: 'msg-1',
+    text: 'Test message',
+    createdAt: new Date('2026-01-01T00:00:00.000Z'),
+    crawledAt: new Date('2026-01-01T01:00:00.000Z'),
+    finalizedAt: new Date('2026-01-01T02:00:00.000Z'),
+    timespanStart: new Date('2026-01-01T00:00:00.000Z'),
+    timespanEnd: new Date('2026-01-10T00:00:00.000Z'),
+    locality: 'bg.sofia',
+    categories: ['water'],
+    cityWide: false,
+    ...overrides,
+  }
+}
+
+function mockCollection(
+  docs: Record<string, unknown>[],
+  findOneResult: Record<string, unknown> | null = null
+) {
+  const cursor = {
+    sort: jest.fn().mockReturnThis(),
+    project: jest.fn().mockReturnThis(),
+    skip: jest.fn().mockReturnThis(),
+    limit: jest.fn().mockReturnThis(),
+    toArray: jest.fn().mockResolvedValue(docs),
+  }
+  return {
+    find: jest.fn().mockReturnValue(cursor),
+    findOne: jest.fn().mockResolvedValue(findOneResult),
+  }
+}
+
+// ─── updates endpoint ─────────────────────────────────────────────────────
+
+describe('updates endpoint (unit)', () => {
+  const originalUri = process.env.YSM_OBOAPP_MONGODB_URI
+
+  beforeEach(() => {
+    process.env.YSM_OBOAPP_MONGODB_URI = 'mongodb://localhost:27017'
+  })
+
+  afterEach(() => {
+    if (originalUri === undefined) {
+      Reflect.deleteProperty(process.env, 'YSM_OBOAPP_MONGODB_URI')
+    } else {
+      process.env.YSM_OBOAPP_MONGODB_URI = originalUri
+    }
+    jest.clearAllMocks()
+  })
+
+  it('returns 500 when YSM_OBOAPP_MONGODB_URI is not configured', async () => {
+    Reflect.deleteProperty(process.env, 'YSM_OBOAPP_MONGODB_URI')
+    const res = await updates.handler({ query: {} } as any)
+    expect(res.status).toBe(500)
+    expect(await res.json()).toEqual({ error: 'YSM_OBOAPP_MONGODB_URI is not configured' })
+  })
+
+  it('returns 500 when Mongo connection fails', async () => {
+    ;(getMessagesCollection as jest.Mock).mockRejectedValue(new Error('connect failed'))
+    const res = await updates.handler({
+      query: {},
+      payload: { logger: { error: jest.fn() } },
+    } as any)
+    expect(res.status).toBe(500)
+    expect(await res.json()).toEqual({ error: 'Failed to connect to OboApp database' })
+  })
+
+  it('returns 200 with mapped messages', async () => {
+    const doc = makeMessage()
+    ;(getMessagesCollection as jest.Mock).mockResolvedValue(mockCollection([doc]))
+    const res = await updates.handler({ query: {} } as any)
+    expect(res.status).toBe(200)
+    const body = await res.json()
+    expect(Array.isArray(body.messages)).toBe(true)
+    expect(body.messages).toHaveLength(1)
+    expect(body.messages[0].id).toBe('msg-1')
+    expect(body.messages[0].text).toBe('Test message')
+  })
+
+  it('adds default timespanEndGte filter when missing', async () => {
+    const col = mockCollection([])
+    ;(getMessagesCollection as jest.Mock).mockResolvedValue(col)
+    await updates.handler({ query: {} } as any)
+    const filterArg = col.find.mock.calls[0][0]
+    expect(filterArg.timespanEnd).toBeDefined()
+    expect(filterArg.timespanEnd.$gte).toBeInstanceOf(Date)
+  })
+
+  it('preserves provided timespanEndGte filter', async () => {
+    const col = mockCollection([])
+    ;(getMessagesCollection as jest.Mock).mockResolvedValue(col)
+    await updates.handler({ query: { timespanEndGte: '2026-02-23T00:00:00.000Z' } } as any)
+    const filterArg = col.find.mock.calls[0][0]
+    expect(filterArg.timespanEnd.$gte).toEqual(new Date('2026-02-23T00:00:00.000Z'))
+  })
+
+  it('applies categories $in filter when categories are given', async () => {
+    const col = mockCollection([])
+    ;(getMessagesCollection as jest.Mock).mockResolvedValue(col)
+    await updates.handler({ query: { categories: 'water,traffic' } } as any)
+    const filterArg = col.find.mock.calls[0][0]
+    expect(filterArg.$or).toBeDefined()
+    const catClause = filterArg.$or.find((c: Record<string, unknown>) => c.categories)
+    expect(catClause.categories.$in).toEqual(expect.arrayContaining(['water', 'traffic']))
+    const cityWideClause = filterArg.$or.find((c: Record<string, unknown>) => c.cityWide)
+    expect(cityWideClause.cityWide).toBe(true)
+  })
+
+  it('does not include $or filter when no categories are given', async () => {
+    const col = mockCollection([])
+    ;(getMessagesCollection as jest.Mock).mockResolvedValue(col)
+    await updates.handler({ query: {} } as any)
+    const filterArg = col.find.mock.calls[0][0]
+    expect(filterArg.$or).toBeUndefined()
+  })
+
+  it('drops messages that have pins with null timespans.start', async () => {
+    const goodDoc = makeMessage({ _id: 'good', pins: [] })
+    const badDoc = makeMessage({
+      _id: 'bad',
+      pins: [{ address: 'Test', timespans: [{ start: null, end: '2026-01-10T00:00:00.000Z' }] }],
+    })
+    ;(getMessagesCollection as jest.Mock).mockResolvedValue(mockCollection([goodDoc, badDoc]))
+    const res = await updates.handler({
+      query: {},
+      payload: { logger: { warn: jest.fn(), error: jest.fn() } },
+    } as any)
+    const body = await res.json()
+    expect(body.messages.map((m: { id: string }) => m.id)).toEqual(['good'])
+  })
+
+  it('applies viewport bounds filter in-memory', async () => {
+    const inBoundsDoc = makeMessage({
+      _id: 'in',
+      geoJson: {
+        type: 'FeatureCollection',
+        features: [
+          {
+            type: 'Feature',
+            geometry: { type: 'Point', coordinates: [23.3, 42.7] },
+            properties: {},
+          },
+        ],
+      },
+    })
+    const outOfBoundsDoc = makeMessage({
+      _id: 'out',
+      geoJson: {
+        type: 'FeatureCollection',
+        features: [
+          {
+            type: 'Feature',
+            geometry: { type: 'Point', coordinates: [24.0, 43.5] },
+            properties: {},
+          },
+        ],
+      },
+    })
+    ;(getMessagesCollection as jest.Mock).mockResolvedValue(
+      mockCollection([inBoundsDoc, outOfBoundsDoc])
+    )
+    const res = await updates.handler({
+      query: { north: '43.0', south: '42.5', east: '23.5', west: '23.0' },
+    } as any)
+    const body = await res.json()
+    expect(body.messages.map((m: { id: string }) => m.id)).toEqual(['in'])
+  })
+
+  it('always includes cityWide messages when bounds filter is active', async () => {
+    const cityWideDoc = makeMessage({ _id: 'cw', cityWide: true, geoJson: undefined })
+    const normalDoc = makeMessage({
+      _id: 'normal',
+      geoJson: {
+        type: 'FeatureCollection',
+        features: [
+          {
+            type: 'Feature',
+            geometry: { type: 'Point', coordinates: [30.0, 50.0] },
+            properties: {},
+          },
+        ],
+      },
+    })
+    ;(getMessagesCollection as jest.Mock).mockResolvedValue(
+      mockCollection([cityWideDoc, normalDoc])
+    )
+    const res = await updates.handler({
+      query: { north: '43.0', south: '42.5', east: '23.5', west: '23.0' },
+    } as any)
+    const body = await res.json()
+    expect(body.messages.map((m: { id: string }) => m.id)).toContain('cw')
+    expect(body.messages.map((m: { id: string }) => m.id)).not.toContain('normal')
+  })
+
+  it('does not call fetch (no upstream proxy)', async () => {
+    const originalFetch = global.fetch
+    global.fetch = jest.fn()
+    ;(getMessagesCollection as jest.Mock).mockResolvedValue(mockCollection([]))
+    await updates.handler({ query: {} } as any)
+    expect(global.fetch).not.toHaveBeenCalled()
+    global.fetch = originalFetch
+  })
+
+  it('applies default pagination when limit/offset are not provided', async () => {
+    const col = mockCollection([])
+    ;(getMessagesCollection as jest.Mock).mockResolvedValue(col)
+    await updates.handler({ query: {} } as any)
+    expect(col.find).toHaveBeenCalledTimes(1)
+    const cursor = col.find.mock.results[0]!.value
+    expect(cursor.skip).toHaveBeenCalledWith(0)
+    expect(cursor.limit).toHaveBeenCalledWith(200)
+  })
+
+  it('caps requested limit to hard maximum', async () => {
+    const col = mockCollection([])
+    ;(getMessagesCollection as jest.Mock).mockResolvedValue(col)
+    await updates.handler({ query: { limit: '9999' } } as any)
+    expect(col.find).toHaveBeenCalledTimes(1)
+    const cursor = col.find.mock.results[0]!.value
+    expect(cursor.limit).toHaveBeenCalledWith(500)
+  })
+
+  it('returns 400 for invalid limit', async () => {
+    const res = await updates.handler({ query: { limit: '-1' } } as any)
+    expect(res.status).toBe(400)
+    expect(await res.json()).toEqual({ error: 'Invalid limit value' })
+  })
+})
+
+// ─── updatesById endpoint ─────────────────────────────────────────────────
+
+describe('updatesById endpoint (unit)', () => {
+  const originalUri = process.env.YSM_OBOAPP_MONGODB_URI
+
+  beforeEach(() => {
+    process.env.YSM_OBOAPP_MONGODB_URI = 'mongodb://localhost:27017'
+  })
+
+  afterEach(() => {
+    if (originalUri === undefined) {
+      Reflect.deleteProperty(process.env, 'YSM_OBOAPP_MONGODB_URI')
+    } else {
+      process.env.YSM_OBOAPP_MONGODB_URI = originalUri
+    }
+    jest.clearAllMocks()
+  })
+
+  it('returns 400 when id is missing', async () => {
+    const res = await updatesById.handler({ query: {} } as any)
+    expect(res.status).toBe(400)
+    expect(await res.json()).toEqual({ error: 'Missing required query parameter: id' })
+  })
+
+  it.each([
+    ['', 'empty string'],
+    ['   ', 'whitespace-only string'],
+  ])('returns 400 when id is %s', async (id) => {
+    const res = await updatesById.handler({ query: { id } } as any)
+    expect(res.status).toBe(400)
+    expect(await res.json()).toEqual({ error: 'Missing required query parameter: id' })
+  })
+
+  it('returns 500 when YSM_OBOAPP_MONGODB_URI is not configured', async () => {
+    Reflect.deleteProperty(process.env, 'YSM_OBOAPP_MONGODB_URI')
+    const res = await updatesById.handler({ query: { id: 'msg-1' } } as any)
+    expect(res.status).toBe(500)
+    expect(await res.json()).toEqual({ error: 'YSM_OBOAPP_MONGODB_URI is not configured' })
+  })
+
+  it('returns 404 when message is not found', async () => {
+    ;(getMessagesCollection as jest.Mock).mockResolvedValue(mockCollection([], null))
+    const res = await updatesById.handler({ query: { id: 'msg-1' } } as any)
+    expect(res.status).toBe(404)
+    expect(await res.json()).toEqual({ error: 'Message not found' })
+  })
+
+  it('returns 200 with message when found by _id', async () => {
+    const doc = makeMessage({ _id: 'msg-1' })
+    ;(getMessagesCollection as jest.Mock).mockResolvedValue(mockCollection([], doc))
+    const res = await updatesById.handler({ query: { id: 'msg-1' } } as any)
+    expect(res.status).toBe(200)
+    const body = await res.json()
+    expect(body.message.id).toBe('msg-1')
+  })
+
+  it('trims whitespace from id before lookup', async () => {
+    const col = mockCollection([], makeMessage({ _id: 'msg-1' }))
+    ;(getMessagesCollection as jest.Mock).mockResolvedValue(col)
+    await updatesById.handler({ query: { id: '  msg-1  ' } } as any)
+    expect(col.findOne).toHaveBeenCalledWith({ _id: 'msg-1', locality: 'bg.sofia' })
+  })
+
+  it('accepts array id values by using first valid entry', async () => {
+    const col = mockCollection([], makeMessage({ _id: 'msg-1' }))
+    ;(getMessagesCollection as jest.Mock).mockResolvedValue(col)
+    const res = await updatesById.handler({ query: { id: ['msg-1'] } } as any)
+    expect(res.status).toBe(200)
+  })
+
+  it('extracts loose id from raw URL when query parsing is incomplete', async () => {
+    const col = mockCollection([], makeMessage({ _id: 'aHR0cHM6Ly9leGFtcGxlLmNvbS8_-1' }))
+    ;(getMessagesCollection as jest.Mock).mockResolvedValue(col)
+    const res = await updatesById.handler({
+      query: {},
+      url: '/api/updates/by-id?id=aHR0cHM6Ly9leGFtcGxlLmNvbS8_-1',
+    } as any)
+    expect(res.status).toBe(200)
+    expect(col.findOne).toHaveBeenCalledWith({
+      _id: 'aHR0cHM6Ly9leGFtcGxlLmNvbS8_-1',
+      locality: 'bg.sofia',
+    })
+  })
+
+  it('falls back to sourceDocumentId lookup when _id is not found', async () => {
+    const col = {
+      find: jest.fn(),
+      findOne: jest
+        .fn()
+        .mockResolvedValueOnce(null) // _id not found
+        .mockResolvedValueOnce(makeMessage({ _id: 'sourceDocId-123' })), // sourceDocumentId found
+    }
+    ;(getMessagesCollection as jest.Mock).mockResolvedValue(col)
+    const res = await updatesById.handler({ query: { id: 'sourceDocId-123' } } as any)
+    expect(res.status).toBe(200)
+    expect(col.findOne).toHaveBeenNthCalledWith(2, {
+      sourceDocumentId: 'sourceDocId-123',
+      locality: 'bg.sofia',
+    })
+  })
+})
+
+// ─── updatesOpenApi endpoint ──────────────────────────────────────────────
+
+describe('updates openapi endpoint (unit)', () => {
+  it('returns schema with expected public paths', async () => {
+    const res = await updatesOpenApi.handler({} as any)
+    expect(res.status).toBe(200)
+    const body = await res.json()
+    expect(body).toHaveProperty('openapi', '3.1.0')
+    expect(body.paths).toHaveProperty('/api/updates')
+    expect(body.paths).toHaveProperty('/api/updates/by-id')
+    expect(body.paths).toHaveProperty('/api/updates-export')
+    expect(body.paths).toHaveProperty('/api/updates/sources')
+    expect(body.paths['/api/updates/sources'].get.deprecated).toBe(true)
+    expect(body.paths['/api/updates'].get.responses).toHaveProperty('400')
+    expect(body.paths['/api/updates'].get.responses).toHaveProperty('500')
+    expect(body.paths['/api/updates/by-id'].get.responses).toHaveProperty('400')
+    expect(body.paths['/api/updates/by-id'].get.responses).toHaveProperty('404')
+    expect(body.paths['/api/updates-export'].get.responses).toHaveProperty('401')
+    expect(body.paths['/api/updates-export'].get.responses).toHaveProperty('413')
+    expect(body.paths['/api/updates/sources'].get.responses).toHaveProperty('401')
+    expect(body.paths['/api/updates/sources'].get.responses).toHaveProperty('403')
+    expect(body.paths['/api/updates/sources'].get.responses).toHaveProperty('404')
+    expect(body.paths['/api/updates/sources'].get.responses).toHaveProperty('502')
+  })
+})
+
+describe('updatesSources endpoint (unit)', () => {
   const originalBaseUrl = process.env.OBOAPP_UPDATES_BASE_URL
   const originalApiKey = process.env.OBOAPP_API_KEY
   const originalNodeEnv = process.env.NODE_ENV
   const originalFetch = global.fetch
-  let consoleErrorSpy: jest.SpyInstance
 
   beforeEach(() => {
     process.env.OBOAPP_UPDATES_BASE_URL = 'https://obo.example.com/api/v1'
     process.env.OBOAPP_API_KEY = 'test-api-key'
     Reflect.set(process.env, 'NODE_ENV', 'test')
     global.fetch = jest.fn()
-    consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation(() => {})
   })
 
   afterEach(() => {
@@ -38,332 +407,6 @@ describe('updates proxy endpoints (unit)', () => {
     }
 
     global.fetch = originalFetch
-    consoleErrorSpy.mockRestore()
-  })
-
-  it('proxies updates list and forwards query params', async () => {
-    ;(global.fetch as jest.Mock).mockResolvedValue(
-      new Response(JSON.stringify({ messages: [] }), {
-        status: 200,
-        headers: {
-          'content-type': 'application/json',
-        },
-      })
-    )
-
-    const res = await updates.handler({
-      query: {
-        categories: 'water,traffic',
-        north: '42.9',
-      },
-    } as any)
-
-    expect(global.fetch).toHaveBeenCalledTimes(1)
-    const calledUrl = String((global.fetch as jest.Mock).mock.calls[0][0])
-    expect(calledUrl).toContain('https://obo.example.com/api/v1/messages?')
-    expect(calledUrl).toContain('categories=water%2Ctraffic')
-    expect(calledUrl).toContain('north=42.9')
-    expect((global.fetch as jest.Mock).mock.calls[0][1]?.headers).toMatchObject({
-      'X-Api-Key': 'test-api-key',
-    })
-
-    expect(res.status).toBe(200)
-    expect(await res.json()).toEqual({ messages: [] })
-  })
-
-  it('forwards array query parameters as repeated params', async () => {
-    ;(global.fetch as jest.Mock).mockResolvedValue(
-      new Response(JSON.stringify({ messages: [] }), {
-        status: 200,
-        headers: {
-          'content-type': 'application/json',
-        },
-      })
-    )
-
-    const res = await updates.handler({
-      query: {
-        categories: ['water', 'traffic'],
-      },
-    } as any)
-
-    expect(global.fetch).toHaveBeenCalledTimes(1)
-    const calledUrl = String((global.fetch as jest.Mock).mock.calls[0][0])
-    expect(calledUrl).toContain('https://obo.example.com/api/v1/messages?')
-    expect(calledUrl).toContain('categories=water')
-    expect(calledUrl).toContain('categories=traffic')
-
-    expect(res.status).toBe(200)
-    expect(await res.json()).toEqual({ messages: [] })
-  })
-
-  it('adds default timespanEndGte filter when missing', async () => {
-    ;(global.fetch as jest.Mock).mockResolvedValue(
-      new Response(JSON.stringify({ messages: [] }), {
-        status: 200,
-        headers: {
-          'content-type': 'application/json',
-        },
-      })
-    )
-
-    const res = await updates.handler({ query: {} } as any)
-
-    expect(global.fetch).toHaveBeenCalledTimes(1)
-    const calledUrl = new URL(String((global.fetch as jest.Mock).mock.calls[0][0]))
-    const timespanEndGte = calledUrl.searchParams.get('timespanEndGte')
-
-    expect(timespanEndGte).toBeTruthy()
-    expect(Number.isNaN(Date.parse(timespanEndGte!))).toBe(false)
-    expect(res.status).toBe(200)
-  })
-
-  it('preserves provided timespanEndGte filter', async () => {
-    ;(global.fetch as jest.Mock).mockResolvedValue(
-      new Response(JSON.stringify({ messages: [] }), {
-        status: 200,
-        headers: {
-          'content-type': 'application/json',
-        },
-      })
-    )
-
-    const providedFilter = '2026-02-23T00:00:00.000Z'
-    const res = await updates.handler({ query: { timespanEndGte: providedFilter } } as any)
-
-    expect(global.fetch).toHaveBeenCalledTimes(1)
-    const calledUrl = new URL(String((global.fetch as jest.Mock).mock.calls[0][0]))
-    expect(calledUrl.searchParams.get('timespanEndGte')).toBe(providedFilter)
-    expect(res.status).toBe(200)
-  })
-
-  it('returns 400 when id is missing for updates-by-id', async () => {
-    const res = await updatesById.handler({ query: {} } as any)
-
-    expect(res.status).toBe(400)
-    expect(await res.json()).toEqual({ error: 'Missing required query parameter: id' })
-  })
-
-  it.each([
-    ['', 'empty string'],
-    ['   ', 'whitespace-only string'],
-  ])('returns 400 when id is %s for updates-by-id', async (id) => {
-    const res = await updatesById.handler({ query: { id } } as any)
-
-    expect(res.status).toBe(400)
-    expect(await res.json()).toEqual({ error: 'Missing required query parameter: id' })
-  })
-
-  it('accepts array id values for updates-by-id by using first valid entry', async () => {
-    ;(global.fetch as jest.Mock).mockResolvedValue(
-      new Response(JSON.stringify({ message: { id: 'm-1' } }), {
-        status: 200,
-        headers: {
-          'content-type': 'application/json',
-        },
-      })
-    )
-
-    const res = await updatesById.handler({ query: { id: ['m-1'] } } as any)
-
-    expect(global.fetch).toHaveBeenCalledTimes(1)
-    const calledUrl = String((global.fetch as jest.Mock).mock.calls[0][0])
-    expect(calledUrl).toContain('https://obo.example.com/api/v1/messages/by-id?id=m-1')
-    expect(res.status).toBe(200)
-    expect(await res.json()).toEqual({ message: { id: 'm-1' } })
-  })
-
-  it('proxies update-by-id when id is provided', async () => {
-    ;(global.fetch as jest.Mock).mockResolvedValue(
-      new Response(JSON.stringify({ message: { id: 'm-1' } }), {
-        status: 200,
-        headers: {
-          'content-type': 'application/json',
-        },
-      })
-    )
-
-    const res = await updatesById.handler({
-      query: {
-        id: 'm-1',
-      },
-    } as any)
-
-    expect(global.fetch).toHaveBeenCalledTimes(1)
-    const calledUrl = String((global.fetch as jest.Mock).mock.calls[0][0])
-    expect(calledUrl).toContain('https://obo.example.com/api/v1/messages/by-id?id=m-1')
-
-    expect(res.status).toBe(200)
-    expect(await res.json()).toEqual({ message: { id: 'm-1' } })
-  })
-
-  it('forwards trimmed id to upstream for updates-by-id', async () => {
-    ;(global.fetch as jest.Mock).mockResolvedValue(
-      new Response(JSON.stringify({ message: { id: 'm-1' } }), {
-        status: 200,
-        headers: {
-          'content-type': 'application/json',
-        },
-      })
-    )
-
-    const res = await updatesById.handler({
-      query: {
-        id: '  m-1  ',
-      },
-    } as any)
-
-    expect(global.fetch).toHaveBeenCalledTimes(1)
-    const calledUrl = String((global.fetch as jest.Mock).mock.calls[0][0])
-    expect(calledUrl).toContain('https://obo.example.com/api/v1/messages/by-id?id=m-1')
-
-    expect(res.status).toBe(200)
-    expect(await res.json()).toEqual({ message: { id: 'm-1' } })
-  })
-
-  it('extracts loose id from raw URL when query parsing is incomplete', async () => {
-    ;(global.fetch as jest.Mock).mockResolvedValue(
-      new Response(JSON.stringify({ message: { id: 'aHR0cHM6Ly9leGFtcGxlLmNvbS8_-1' } }), {
-        status: 200,
-        headers: {
-          'content-type': 'application/json',
-        },
-      })
-    )
-
-    const res = await updatesById.handler({
-      query: {},
-      url: '/api/updates/by-id?id=aHR0cHM6Ly9leGFtcGxlLmNvbS8_-1',
-    } as any)
-
-    expect(global.fetch).toHaveBeenCalledTimes(1)
-    const calledUrl = String((global.fetch as jest.Mock).mock.calls[0][0])
-    expect(calledUrl).toContain(
-      'https://obo.example.com/api/v1/messages/by-id?id=aHR0cHM6Ly9leGFtcGxlLmNvbS8_-1'
-    )
-
-    expect(res.status).toBe(200)
-    expect(await res.json()).toEqual({ message: { id: 'aHR0cHM6Ly9leGFtcGxlLmNvbS8_-1' } })
-  })
-
-  it('returns 500 when OBOAPP_UPDATES_BASE_URL is not configured', async () => {
-    Reflect.deleteProperty(process.env, 'OBOAPP_UPDATES_BASE_URL')
-
-    const res = await updates.handler({ query: {} } as any)
-
-    expect(res.status).toBe(500)
-    expect(await res.json()).toEqual({ error: 'OBOAPP_UPDATES_BASE_URL is not configured' })
-    expect(global.fetch).not.toHaveBeenCalled()
-  })
-
-  it('returns 500 when OBOAPP_UPDATES_BASE_URL is malformed', async () => {
-    process.env.OBOAPP_UPDATES_BASE_URL = 'not a valid url'
-
-    const res = await updates.handler({ query: {} } as any)
-
-    expect(res.status).toBe(500)
-    expect(await res.json()).toEqual({ error: 'OBOAPP_UPDATES_BASE_URL is invalid' })
-    expect(global.fetch).not.toHaveBeenCalled()
-  })
-
-  it('returns 500 when OBOAPP_API_KEY is not configured', async () => {
-    Reflect.deleteProperty(process.env, 'OBOAPP_API_KEY')
-
-    const res = await updates.handler({ query: {} } as any)
-
-    expect(res.status).toBe(500)
-    expect(await res.json()).toEqual({ error: 'OBOAPP_API_KEY is not configured' })
-    expect(global.fetch).not.toHaveBeenCalled()
-  })
-
-  it('returns 502 with timeout-specific error when upstream request aborts', async () => {
-    ;(global.fetch as jest.Mock).mockRejectedValue(
-      new DOMException('The operation was aborted.', 'AbortError')
-    )
-
-    const res = await updates.handler({ query: {} } as any)
-
-    expect(res.status).toBe(502)
-    expect(await res.json()).toMatchObject({
-      error: 'Request timed out after 15 seconds',
-    })
-  })
-
-  it('returns 502 with upstream communication error for non-timeout failures', async () => {
-    Reflect.set(process.env, 'NODE_ENV', 'development')
-    ;(global.fetch as jest.Mock).mockRejectedValue(new Error('network unavailable'))
-
-    const res = await updates.handler({ query: {} } as any)
-
-    expect(res.status).toBe(502)
-    expect(await res.json()).toMatchObject({
-      error: 'Failed to communicate with OboApp upstream API',
-      message: 'network unavailable',
-    })
-  })
-
-  it('does not expose raw upstream error message in production', async () => {
-    Reflect.set(process.env, 'NODE_ENV', 'production')
-    ;(global.fetch as jest.Mock).mockRejectedValue(new Error('network unavailable'))
-
-    const res = await updates.handler({ query: {} } as any)
-
-    expect(res.status).toBe(502)
-    expect(await res.json()).toEqual({
-      error: 'Failed to communicate with OboApp upstream API',
-    })
-  })
-
-  it('maps upstream 5xx responses to 502 with consistent payload', async () => {
-    ;(global.fetch as jest.Mock).mockResolvedValue(
-      new Response('upstream down', {
-        status: 503,
-        headers: {
-          'content-type': 'text/plain',
-        },
-      })
-    )
-
-    const res = await updates.handler({ query: {} } as any)
-
-    expect(res.status).toBe(502)
-    expect(await res.json()).toEqual({
-      error: 'Failed to communicate with OboApp upstream API',
-    })
-  })
-
-  it('passes through upstream 4xx responses', async () => {
-    ;(global.fetch as jest.Mock).mockResolvedValue(
-      new Response(JSON.stringify({ error: 'Not found upstream' }), {
-        status: 404,
-        headers: {
-          'content-type': 'application/json',
-        },
-      })
-    )
-
-    const res = await updates.handler({ query: {} } as any)
-
-    expect(res.status).toBe(404)
-    expect(await res.json()).toEqual({ error: 'Not found upstream' })
-  })
-
-  it('normalizes multiple trailing slashes in upstream base url', async () => {
-    process.env.OBOAPP_UPDATES_BASE_URL = 'https://obo.example.com/api/v1///'
-    ;(global.fetch as jest.Mock).mockResolvedValue(
-      new Response(JSON.stringify({ messages: [] }), {
-        status: 200,
-        headers: {
-          'content-type': 'application/json',
-        },
-      })
-    )
-
-    await updates.handler({ query: {} } as any)
-
-    const calledUrl = String((global.fetch as jest.Mock).mock.calls[0][0])
-    expect(calledUrl).toContain('https://obo.example.com/api/v1/messages')
-    expect(calledUrl).not.toContain('/api/v1//messages')
   })
 
   it('proxies updates sources metadata', async () => {
@@ -388,36 +431,11 @@ describe('updates proxy endpoints (unit)', () => {
     expect(res.status).toBe(200)
     expect(await res.json()).toEqual({ sources: [{ id: 'sofia-bg', name: 'Столична община' }] })
   })
-})
 
-describe('updates openapi endpoint (unit)', () => {
-  it('returns proxy schema with expected public paths', async () => {
-    const res = await updatesOpenApi.handler({} as any)
-
-    expect(res.status).toBe(200)
-    const body = await res.json()
-
-    expect(body).toHaveProperty('openapi', '3.1.0')
-    expect(body.paths).toHaveProperty('/api/updates')
-    expect(body.paths).toHaveProperty('/api/updates/by-id')
-    expect(body.paths).toHaveProperty('/api/updates/sources')
-    expect(body.paths['/api/updates'].get.responses).toHaveProperty('400')
-    expect(body.paths['/api/updates'].get.responses).toHaveProperty('401')
-    expect(body.paths['/api/updates'].get.responses).toHaveProperty('403')
-    expect(body.paths['/api/updates'].get.responses).toHaveProperty('404')
-    expect(body.paths['/api/updates'].get.responses).toHaveProperty('500')
-    expect(body.paths['/api/updates'].get.responses).toHaveProperty('502')
-    expect(body.paths['/api/updates/by-id'].get.responses).toHaveProperty('401')
-    expect(body.paths['/api/updates/by-id'].get.responses).toHaveProperty('403')
-    expect(body.paths['/api/updates/by-id'].get.responses).toHaveProperty('404')
-    expect(body.paths['/api/updates/by-id'].get.responses).toHaveProperty('500')
-    expect(body.paths['/api/updates/by-id'].get.responses).toHaveProperty('502')
-    expect(body.paths['/api/updates/sources'].get.responses).toHaveProperty('401')
-    expect(body.paths['/api/updates/sources'].get.responses).toHaveProperty('403')
-    expect(body.paths['/api/updates/sources'].get.responses).toHaveProperty('404')
-    expect(body.paths['/api/updates/sources'].get.responses).toHaveProperty('500')
-    expect(body.paths['/api/updates/sources'].get.responses).toHaveProperty('502')
-    expect(body.paths).not.toHaveProperty('/api/obo/messages')
-    expect(body.paths).not.toHaveProperty('/api/obo/messages/by-id')
+  it('returns 500 when OBOAPP_UPDATES_BASE_URL is missing', async () => {
+    Reflect.deleteProperty(process.env, 'OBOAPP_UPDATES_BASE_URL')
+    const res = await updatesSources.handler({ query: {} } as any)
+    expect(res.status).toBe(500)
+    expect(await res.json()).toEqual({ error: 'OBOAPP_UPDATES_BASE_URL is not configured' })
   })
 })

--- a/src/endpoints/__tests__/updatesExport.test.ts
+++ b/src/endpoints/__tests__/updatesExport.test.ts
@@ -1,0 +1,224 @@
+import { updatesExport } from '../updatesExport'
+
+// ─── Mock oboMongo ────────────────────────────────────────────────────────
+
+jest.mock('../../lib/oboMongo', () => ({
+  getMessagesCollection: jest.fn(),
+}))
+
+import { getMessagesCollection } from '../../lib/oboMongo'
+
+// ─── Helpers ──────────────────────────────────────────────────────────────
+
+const VALID_SINCE = '2026-01-01T00:00:00.000Z'
+
+function makeReq(
+  overrides: {
+    headers?: Record<string, string>
+    query?: Record<string, unknown>
+    payload?: { logger?: { error?: jest.Mock; warn?: jest.Mock } }
+  } = {}
+) {
+  const headers = new Map(Object.entries({ 'x-api-key': 'secret-key', ...overrides.headers }))
+  return {
+    headers: { get: (k: string) => headers.get(k) ?? null },
+    query: overrides.query !== undefined ? overrides.query : { since: VALID_SINCE },
+    payload: overrides.payload ?? {},
+  } as any
+}
+
+function makeMessageDoc(overrides: Record<string, unknown> = {}): Record<string, unknown> {
+  return {
+    _id: 'msg-export-1',
+    text: 'Export message',
+    createdAt: new Date('2026-01-02T00:00:00.000Z'),
+    crawledAt: new Date('2026-01-02T01:00:00.000Z'),
+    finalizedAt: new Date('2026-01-02T02:00:00.000Z'),
+    timespanStart: new Date('2026-01-02T00:00:00.000Z'),
+    timespanEnd: new Date('2026-01-10T00:00:00.000Z'),
+    locality: 'bg.sofia',
+    categories: ['water'],
+    ...overrides,
+  }
+}
+
+function makeCursor(docs: Record<string, unknown>[]) {
+  return {
+    project: jest.fn().mockReturnThis(),
+    sort: jest.fn().mockReturnThis(),
+    limit: jest.fn().mockReturnThis(),
+    toArray: jest.fn().mockResolvedValue(docs),
+  }
+}
+
+// ─── Tests ────────────────────────────────────────────────────────────────
+
+describe('updatesExport endpoint (unit)', () => {
+  const originalUri = process.env.YSM_OBOAPP_MONGODB_URI
+  const originalKey = process.env.YSM_OBOAPP_SYNC_API_KEY
+
+  beforeEach(() => {
+    process.env.YSM_OBOAPP_MONGODB_URI = 'mongodb://localhost:27017'
+    process.env.YSM_OBOAPP_SYNC_API_KEY = 'secret-key'
+  })
+
+  afterEach(() => {
+    if (originalUri === undefined) {
+      Reflect.deleteProperty(process.env, 'YSM_OBOAPP_MONGODB_URI')
+    } else {
+      process.env.YSM_OBOAPP_MONGODB_URI = originalUri
+    }
+    if (originalKey === undefined) {
+      Reflect.deleteProperty(process.env, 'YSM_OBOAPP_SYNC_API_KEY')
+    } else {
+      process.env.YSM_OBOAPP_SYNC_API_KEY = originalKey
+    }
+    jest.clearAllMocks()
+  })
+
+  // ── Auth ──────────────────────────────────────────────────────────────
+
+  it('returns 401 when X-Api-Key header is missing', async () => {
+    const req = makeReq({ headers: { 'x-api-key': '' } })
+    // Overwrite to simulate absent header
+    req.headers.get = (k: string) => (k === 'x-api-key' ? null : null)
+    const res = await updatesExport.handler(req)
+    expect(res.status).toBe(401)
+    expect(await res.json()).toEqual({ error: 'Unauthorized' })
+  })
+
+  it('returns 401 when X-Api-Key is wrong', async () => {
+    const res = await updatesExport.handler(makeReq({ headers: { 'x-api-key': 'wrong-key' } }))
+    expect(res.status).toBe(401)
+    expect(await res.json()).toEqual({ error: 'Unauthorized' })
+  })
+
+  it('returns 500 when YSM_OBOAPP_SYNC_API_KEY is not configured', async () => {
+    Reflect.deleteProperty(process.env, 'YSM_OBOAPP_SYNC_API_KEY')
+    const res = await updatesExport.handler(makeReq())
+    expect(res.status).toBe(500)
+    expect(await res.json()).toEqual({ error: 'YSM_OBOAPP_SYNC_API_KEY is not configured' })
+  })
+
+  // ── Config ────────────────────────────────────────────────────────────
+
+  it('returns 500 when YSM_OBOAPP_MONGODB_URI is not configured', async () => {
+    Reflect.deleteProperty(process.env, 'YSM_OBOAPP_MONGODB_URI')
+    const res = await updatesExport.handler(makeReq())
+    expect(res.status).toBe(500)
+    expect(await res.json()).toEqual({ error: 'YSM_OBOAPP_MONGODB_URI is not configured' })
+  })
+
+  // ── Input validation ──────────────────────────────────────────────────
+
+  it('returns 400 when since param is missing', async () => {
+    const res = await updatesExport.handler(makeReq({ query: {} }))
+    expect(res.status).toBe(400)
+    expect(await res.json()).toMatchObject({ error: 'Missing required query parameter: since' })
+  })
+
+  it('returns 400 when since is not a valid ISO timestamp', async () => {
+    const res = await updatesExport.handler(makeReq({ query: { since: 'not-a-date' } }))
+    expect(res.status).toBe(400)
+    expect(await res.json()).toMatchObject({ error: expect.stringContaining('Invalid since') })
+  })
+
+  // ── Success ───────────────────────────────────────────────────────────
+
+  it('returns 200 with messages', async () => {
+    const msgDoc = makeMessageDoc()
+    ;(getMessagesCollection as jest.Mock).mockResolvedValue({
+      find: jest.fn().mockReturnValue(makeCursor([msgDoc])),
+    })
+
+    const res = await updatesExport.handler(makeReq())
+    expect(res.status).toBe(200)
+    const body = await res.json()
+    expect(body.since).toBe(VALID_SINCE)
+    expect(body.generatedAt).toBeTruthy()
+    expect(body.messages).toHaveLength(1)
+    expect(body.messages[0].id).toBe('msg-export-1')
+    expect(body).not.toHaveProperty('sources')
+  })
+
+  it('does not include internal message fields in export', async () => {
+    const msgDoc = makeMessageDoc({
+      embedding: [0.1, 0.2],
+      process: 'some-process',
+      ingestErrors: ['err'],
+      isRelevant: false,
+      isUnreadable: true,
+      eventId: 'ev-1',
+      notificationsSent: true,
+    })
+    ;(getMessagesCollection as jest.Mock).mockResolvedValue({
+      find: jest.fn().mockReturnValue(makeCursor([msgDoc])),
+    })
+
+    const res = await updatesExport.handler(makeReq())
+    const body = await res.json()
+    const msg = body.messages[0]
+    expect(msg).not.toHaveProperty('embedding')
+    expect(msg).not.toHaveProperty('process')
+    expect(msg).not.toHaveProperty('ingestErrors')
+    expect(msg).not.toHaveProperty('notificationsSent')
+    expect(msg).not.toHaveProperty('sourceDocumentId')
+    expect(msg).not.toHaveProperty('text')
+    expect(msg).not.toHaveProperty('plainText')
+    expect(msg).not.toHaveProperty('addresses')
+    expect(msg).not.toHaveProperty('finalizedAt')
+  })
+
+  it('includes summary and educationalFacilities when present', async () => {
+    const msgDoc = makeMessageDoc({
+      summary: 'A short summary',
+      educationalFacilities: ['School A', 'School B'],
+    })
+    ;(getMessagesCollection as jest.Mock).mockResolvedValue({
+      find: jest.fn().mockReturnValue(makeCursor([msgDoc])),
+    })
+
+    const res = await updatesExport.handler(makeReq())
+    const body = await res.json()
+    const msg = body.messages[0]
+    expect(msg.summary).toBe('A short summary')
+    expect(msg.educationalFacilities).toEqual(['School A', 'School B'])
+  })
+
+  // ── Overflow ──────────────────────────────────────────────────────────
+
+  it('returns 413 when message count exceeds limit', async () => {
+    process.env.YSM_OBOAPP_SYNC_LIMIT_MAX = '3'
+    const msgs = Array.from({ length: 4 }, (_, i) => makeMessageDoc({ _id: `msg-${i}` }))
+    const countDocuments = jest.fn().mockResolvedValue(42)
+    ;(getMessagesCollection as jest.Mock).mockResolvedValue({
+      find: jest.fn().mockReturnValue(makeCursor(msgs)),
+      countDocuments,
+    })
+
+    const res = await updatesExport.handler(makeReq())
+    expect(res.status).toBe(413)
+    const body = await res.json()
+    expect(body.error).toBe('limitExceeded')
+    expect(body.messageCount).toBe(42)
+    expect(countDocuments).toHaveBeenCalledTimes(1)
+    expect(body).not.toHaveProperty('sourceCount')
+
+    Reflect.deleteProperty(process.env, 'YSM_OBOAPP_SYNC_LIMIT_MAX')
+  })
+
+  it('passes since date as $gt filter to messages collection', async () => {
+    const msgsCursor = makeCursor([])
+    const msgsFindMock = jest.fn().mockReturnValue(msgsCursor)
+    ;(getMessagesCollection as jest.Mock).mockResolvedValue({ find: msgsFindMock })
+
+    await updatesExport.handler(makeReq({ query: { since: VALID_SINCE } }))
+
+    const msgsFilter = msgsFindMock.mock.calls[0][0]
+    expect(msgsFilter.$or).toBeDefined()
+    const crawledGt = msgsFilter.$or.find(
+      (c: Record<string, unknown>) => (c.crawledAt as Record<string, unknown>)?.$gt
+    )
+    expect(crawledGt.crawledAt.$gt).toEqual(new Date(VALID_SINCE))
+  })
+})

--- a/src/endpoints/updates.ts
+++ b/src/endpoints/updates.ts
@@ -1,32 +1,22 @@
 import type { Endpoint } from 'payload'
 import type { Category, Subscription } from '../payload-types'
-import { proxyUpdatesUpstreamGet } from './updatesProxyUtils'
+import { getMessagesCollection, SOFIA_LOCALITY } from '../lib/oboMongo'
+import {
+  docToUpdateMessage,
+  hasNullPinTimespanStart,
+  messageInBounds,
+  sortByRelevance,
+  type ViewportBounds,
+} from '../lib/oboMessageMapper'
 
-type RawMessage = {
-  id?: string
-  text?: string
-  categories?: string[]
-  pins?: Array<{ address?: string; timespans?: Array<{ start?: string | null }> }>
-}
+const DEFAULT_QUERY_LIMIT = 200
+const MAX_QUERY_LIMIT = 500
 
-function hasNullTimespanStart(msg: RawMessage): boolean {
-  return (msg.pins ?? []).some((pin) =>
-    (pin.timespans ?? []).some((ts) => ts.start === null || ts.start === undefined)
-  )
-}
-
-// ─── Bounding-box helpers ──────────────────────────────────────────────────
-
-interface BBox {
-  north: number
-  south: number
-  east: number
-  west: number
-}
+// ─── Bounding-box helpers ────────────────────────────────────────────────
 
 const LAT_DEGREE_METERS = 111_320
 
-function bboxFromPoint(lat: number, lng: number, radiusMeters: number): BBox {
+function bboxFromPoint(lat: number, lng: number, radiusMeters: number): ViewportBounds {
   const dLat = radiusMeters / LAT_DEGREE_METERS
   const dLng = radiusMeters / (LAT_DEGREE_METERS * Math.cos((lat * Math.PI) / 180))
   return { north: lat + dLat, south: lat - dLat, east: lng + dLng, west: lng - dLng }
@@ -35,7 +25,7 @@ function bboxFromPoint(lat: number, lng: number, radiusMeters: number): BBox {
 function bboxFromPolygon(polygon: {
   type: 'Polygon'
   coordinates: [number, number][][]
-}): BBox | null {
+}): ViewportBounds | null {
   const coords = polygon.coordinates.flat()
   if (coords.length === 0) return null
   const lngs = coords.map((c) => c[0])
@@ -48,7 +38,7 @@ function bboxFromPolygon(polygon: {
   }
 }
 
-function unionBBoxes(boxes: BBox[]): BBox {
+function unionBBoxes(boxes: ViewportBounds[]): ViewportBounds {
   return {
     north: Math.max(...boxes.map((b) => b.north)),
     south: Math.min(...boxes.map((b) => b.south)),
@@ -61,7 +51,7 @@ function unionBBoxes(boxes: BBox[]): BBox {
 
 interface ResolvedSubscription {
   categories: string[]
-  bbox: BBox | null
+  bbox: ViewportBounds | null
 }
 
 async function resolveSubscription(
@@ -101,7 +91,7 @@ async function resolveSubscription(
     return { categories, bbox: null }
   }
 
-  const boxes: BBox[] = []
+  const boxes: ViewportBounds[] = []
 
   for (const filter of locationFilters) {
     if (filter.filterType === 'point') {
@@ -189,7 +179,7 @@ export const updates: Endpoint = {
       rawQuery.timespanEndGte = dayStart.toISOString()
     }
 
-    // Resolve the category filter before forwarding (the upstream may not honour it)
+    // Parse the category filter
     const categoriesFilter =
       typeof rawQuery.categories === 'string' && rawQuery.categories.trim()
         ? rawQuery.categories
@@ -198,45 +188,125 @@ export const updates: Endpoint = {
             .filter(Boolean)
         : null
 
-    const upstreamResponse = await proxyUpdatesUpstreamGet('/messages', rawQuery, {
-      logger: req.payload?.logger,
-    })
+    // Parse optional viewport bounds
+    const toNum = (v: unknown): number | undefined => {
+      if (typeof v === 'string' && v.trim() === '') return undefined
+      const n = Number(v)
+      return Number.isFinite(n) ? n : undefined
+    }
+    const north = toNum(rawQuery.north)
+    const south = toNum(rawQuery.south)
+    const east = toNum(rawQuery.east)
+    const west = toNum(rawQuery.west)
+    const hasBounds =
+      north !== undefined && south !== undefined && east !== undefined && west !== undefined
+    const bounds: ViewportBounds | null = hasBounds
+      ? { north: north!, south: south!, east: east!, west: west! }
+      : null
 
-    // Post-filter by categories when requested — the upstream API returns all messages
-    // regardless of the `categories` param; filtering must be applied here.
-    // Also drop messages that have pins with a null timespan start.
-    if (upstreamResponse.ok) {
-      try {
-        const body = await upstreamResponse.json()
-        let messages: RawMessage[] = body.messages ?? []
-
-        // Drop messages with null pin timespan starts
-        messages = messages.filter((msg) => {
-          if (hasNullTimespanStart(msg)) {
-            req.payload?.logger?.warn(
-              { messageId: msg.id, text: msg.text?.slice(0, 120) },
-              '[updates] Dropping message — pin has null timespans.start'
-            )
-            return false
-          }
-          return true
-        })
-
-        if (categoriesFilter && categoriesFilter.length > 0) {
-          messages = messages.filter(
-            (msg) =>
-              Array.isArray(msg.categories) &&
-              msg.categories.some((cat) => categoriesFilter.includes(cat.toLowerCase()))
-          )
-        }
-
-        return Response.json({ ...body, messages })
-      } catch (err) {
-        req.payload?.logger?.error({ err }, '[updates] Failed to post-process upstream response')
-        return upstreamResponse
-      }
+    // Parse timespanEndGte (already defaulted above)
+    const timespanEndGte = rawQuery.timespanEndGte
+    const cutoffDate = timespanEndGte ? new Date(String(timespanEndGte)) : new Date()
+    if (Number.isNaN(cutoffDate.getTime())) {
+      return Response.json({ error: 'Invalid timespanEndGte value' }, { status: 400 })
     }
 
-    return upstreamResponse
+    const parseNonNegativeInt = (value: unknown, field: 'limit' | 'offset'): number | null => {
+      if (value === undefined || value === null || value === '') {
+        return field === 'limit' ? DEFAULT_QUERY_LIMIT : 0
+      }
+      const parsed = Number.parseInt(String(value), 10)
+      if (Number.isNaN(parsed) || parsed < 0) return null
+      return parsed
+    }
+
+    const requestedLimit = parseNonNegativeInt(rawQuery.limit, 'limit')
+    if (requestedLimit === null) {
+      return Response.json({ error: 'Invalid limit value' }, { status: 400 })
+    }
+    const offset = parseNonNegativeInt(rawQuery.offset, 'offset')
+    if (offset === null) {
+      return Response.json({ error: 'Invalid offset value' }, { status: 400 })
+    }
+    const limit = Math.min(requestedLimit, MAX_QUERY_LIMIT)
+
+    // ── Build Mongo filter ───────────────────────────────────────────────
+    if (!process.env.YSM_OBOAPP_MONGODB_URI) {
+      return Response.json({ error: 'YSM_OBOAPP_MONGODB_URI is not configured' }, { status: 500 })
+    }
+
+    let messagesCollection: Awaited<ReturnType<typeof getMessagesCollection>>
+    try {
+      messagesCollection = await getMessagesCollection()
+    } catch (err) {
+      req.payload?.logger?.error({ err }, '[updates] Failed to connect to OboApp MongoDB')
+      return Response.json({ error: 'Failed to connect to OboApp database' }, { status: 500 })
+    }
+
+    // timespanEnd is stored as BSON Date by OboApp (confirmed in firestore-to-mongo migration);
+    // Date comparison is correct here.
+    const mongoFilter: Record<string, unknown> = {
+      timespanEnd: { $gte: cutoffDate },
+      locality: SOFIA_LOCALITY,
+    }
+
+    if (categoriesFilter && categoriesFilter.length > 0) {
+      // Include messages that match any requested category OR are cityWide
+      mongoFilter.$or = [{ categories: { $in: categoriesFilter } }, { cityWide: true }]
+    }
+
+    let rawDocs: Record<string, unknown>[]
+    try {
+      rawDocs = (await messagesCollection
+        .find(mongoFilter)
+        // Exclude large internal fields not used by docToUpdateMessage
+        .project({ embedding: 0, process: 0, ingestErrors: 0 })
+        .sort({ finalizedAt: -1, timespanEnd: -1 })
+        .skip(offset)
+        .limit(limit)
+        .toArray()) as Record<string, unknown>[]
+    } catch (err) {
+      req.payload?.logger?.error({ err }, '[updates] Mongo query failed')
+      return Response.json({ error: 'Failed to query OboApp database' }, { status: 500 })
+    }
+
+    // ── Map, filter and sort ─────────────────────────────────────────────
+    let messages = rawDocs
+      .map((doc) => {
+        const msg = docToUpdateMessage(doc)
+        if (!msg) {
+          req.payload?.logger?.warn(
+            { docId: String(doc._id ?? '') },
+            '[updates] Skipping malformed message document'
+          )
+        }
+        return msg
+      })
+      .filter((msg): msg is NonNullable<typeof msg> => msg !== null)
+
+    // Drop messages with null pin timespan starts
+    messages = messages.filter((msg) => {
+      if (hasNullPinTimespanStart(msg)) {
+        req.payload?.logger?.warn(
+          { messageId: msg.id, text: msg.text?.slice(0, 120) },
+          '[updates] Dropping message — pin has null timespans.start'
+        )
+        return false
+      }
+      return true
+    })
+
+    // Apply viewport bounds filter
+    if (bounds) {
+      messages = messages.filter((msg) => messageInBounds(msg, bounds))
+    }
+
+    return Response.json({
+      messages: sortByRelevance(messages),
+      pagination: {
+        limit,
+        offset,
+      },
+    })
   },
 }

--- a/src/endpoints/updatesById.ts
+++ b/src/endpoints/updatesById.ts
@@ -1,5 +1,6 @@
 import type { Endpoint } from 'payload'
-import { proxyUpdatesUpstreamGet } from './updatesProxyUtils'
+import { getMessagesCollection, SOFIA_LOCALITY } from '../lib/oboMongo'
+import { docToUpdateMessage } from '../lib/oboMessageMapper'
 
 function normalizeIdValue(value: unknown): string | null {
   if (typeof value === 'string') {
@@ -59,13 +60,47 @@ export const updatesById: Endpoint = {
       return Response.json({ error: 'Missing required query parameter: id' }, { status: 400 })
     }
 
-    const upstreamQuery = {
-      ...(req.query as Record<string, unknown> | undefined),
-      id,
+    if (!process.env.YSM_OBOAPP_MONGODB_URI) {
+      return Response.json({ error: 'YSM_OBOAPP_MONGODB_URI is not configured' }, { status: 500 })
     }
 
-    return proxyUpdatesUpstreamGet('/messages/by-id', upstreamQuery, {
-      logger: req.payload?.logger,
-    })
+    let messagesCollection: Awaited<ReturnType<typeof getMessagesCollection>>
+    try {
+      messagesCollection = await getMessagesCollection()
+    } catch (err) {
+      req.payload?.logger?.error({ err }, '[updatesById] Failed to connect to OboApp MongoDB')
+      return Response.json({ error: 'Failed to connect to OboApp database' }, { status: 500 })
+    }
+
+    let doc: Record<string, unknown> | null = null
+    try {
+      // OboApp stores _id as a plain string (not ObjectId) — string equality match is correct.
+      doc = (await messagesCollection.findOne({
+        _id: id as any,
+        locality: SOFIA_LOCALITY,
+      })) as Record<string, unknown> | null
+
+      // Fallback: look up by sourceDocumentId (Firestore doc ID preserved on migration)
+      if (!doc) {
+        doc = (await messagesCollection.findOne({
+          sourceDocumentId: id,
+          locality: SOFIA_LOCALITY,
+        })) as Record<string, unknown> | null
+      }
+    } catch (err) {
+      req.payload?.logger?.error({ err }, '[updatesById] Mongo query failed')
+      return Response.json({ error: 'Failed to query OboApp database' }, { status: 500 })
+    }
+
+    if (!doc) {
+      return Response.json({ error: 'Message not found' }, { status: 404 })
+    }
+
+    const message = docToUpdateMessage(doc)
+    if (!message) {
+      return Response.json({ error: 'Message data is malformed' }, { status: 500 })
+    }
+
+    return Response.json({ message })
   },
 }

--- a/src/endpoints/updatesExport.ts
+++ b/src/endpoints/updatesExport.ts
@@ -1,0 +1,195 @@
+/**
+ * GET /api/updates-export
+ *
+ * Private endpoint to allow oboapp.online to fetch incremental messages since a given timestamp.
+ *
+ * Auth: X-Api-Key header must match YSM_OBOAPP_SYNC_API_KEY.
+ *
+ * Query params:
+ *   since=<ISO 8601>   — return records crawled/finalized after this timestamp
+ *
+ * Response 200:
+ *   { since, generatedAt, messages: ExportMessage[] }
+ *
+ * Response 413:
+ *   { error: 'limitExceeded', messageCount: number }
+ *   Caller should retry with a more recent `since` value.
+ */
+import type { Endpoint } from 'payload'
+import { timingSafeEqual } from 'crypto'
+import { getMessagesCollection, SOFIA_LOCALITY } from '../lib/oboMongo'
+import {
+  docToUpdateMessage,
+  type GeoJsonFeatureCollection,
+  type UpdateCadastralProperty,
+  type UpdatePin,
+  type UpdateStreet,
+} from '../lib/oboMessageMapper'
+
+const DEFAULT_LIMIT_MAX = 100
+
+// ─── Export message shape ─────────────────────────────────────────────────
+
+export interface ExportMessage {
+  id?: string
+  locality?: string
+  source?: string
+  createdAt: string
+  crawledAt?: string
+  sourceUrl?: string
+  markdownText?: string
+  responsibleEntity?: string
+  summary?: string
+  geoJson?: GeoJsonFeatureCollection
+  categories?: string[]
+  busStops?: string[]
+  cadastralProperties?: UpdateCadastralProperty[]
+  cityWide?: boolean
+  educationalFacilities?: string[]
+  pins?: UpdatePin[]
+  streets?: UpdateStreet[]
+  timespanEnd?: string
+  timespanStart?: string
+}
+
+function docToExportMessage(doc: Record<string, unknown>): ExportMessage | null {
+  const base = docToUpdateMessage(doc)
+  if (!base) return null
+
+  return {
+    id: base.id,
+    locality: base.locality,
+    source: base.source,
+    createdAt: base.createdAt,
+    crawledAt: base.crawledAt,
+    sourceUrl: base.sourceUrl,
+    markdownText: base.markdownText,
+    responsibleEntity: base.responsibleEntity,
+    summary: typeof doc.summary === 'string' ? doc.summary : undefined,
+    geoJson: base.geoJson,
+    categories: base.categories,
+    busStops: base.busStops,
+    cadastralProperties: base.cadastralProperties,
+    cityWide: base.cityWide,
+    educationalFacilities: Array.isArray(doc.educationalFacilities)
+      ? doc.educationalFacilities.filter((v): v is string => typeof v === 'string')
+      : undefined,
+    pins: base.pins,
+    streets: base.streets,
+    timespanEnd: base.timespanEnd,
+    timespanStart: base.timespanStart,
+  }
+}
+
+// ─── Endpoint ─────────────────────────────────────────────────────────────
+
+export const updatesExport: Endpoint = {
+  path: '/updates-export',
+  method: 'get',
+  handler: async (req) => {
+    // ── Auth ──────────────────────────────────────────────────────────────
+    const expectedKey = process.env.YSM_OBOAPP_SYNC_API_KEY
+    if (!expectedKey) {
+      return Response.json({ error: 'YSM_OBOAPP_SYNC_API_KEY is not configured' }, { status: 500 })
+    }
+
+    const providedKey = req.headers.get('x-api-key') ?? ''
+    const expectedBuf = Buffer.from(expectedKey)
+    const providedBuf = Buffer.alloc(expectedBuf.length)
+    Buffer.from(providedKey).copy(providedBuf, 0, 0, expectedBuf.length)
+    if (!timingSafeEqual(expectedBuf, providedBuf) || providedKey.length !== expectedKey.length) {
+      return Response.json({ error: 'Unauthorized' }, { status: 401 })
+    }
+
+    // ── Mongo config ──────────────────────────────────────────────────────
+    if (!process.env.YSM_OBOAPP_MONGODB_URI) {
+      return Response.json({ error: 'YSM_OBOAPP_MONGODB_URI is not configured' }, { status: 500 })
+    }
+
+    // ── Query params ──────────────────────────────────────────────────────
+    const query = (req.query as Record<string, unknown>) ?? {}
+
+    const sinceRaw = typeof query.since === 'string' ? query.since.trim() : undefined
+    if (!sinceRaw) {
+      return Response.json({ error: 'Missing required query parameter: since' }, { status: 400 })
+    }
+
+    const sinceDate = new Date(sinceRaw)
+    if (Number.isNaN(sinceDate.getTime())) {
+      return Response.json(
+        { error: 'Invalid since value — must be an ISO 8601 timestamp' },
+        { status: 400 }
+      )
+    }
+
+    const limitMax = (() => {
+      const parsed = Number.parseInt(process.env.YSM_OBOAPP_SYNC_LIMIT_MAX ?? '', 10)
+      return Number.isNaN(parsed) || parsed <= 0 ? DEFAULT_LIMIT_MAX : parsed
+    })()
+
+    // ── Fetch messages ────────────────────────────────────────────────────
+    let messagesCollection: Awaited<ReturnType<typeof getMessagesCollection>>
+    try {
+      messagesCollection = await getMessagesCollection()
+    } catch (err) {
+      req.payload?.logger?.error({ err }, '[updatesExport] Failed to connect to updates database')
+      return Response.json({ error: 'Failed to connect to updates database' }, { status: 500 })
+    }
+
+    let rawMessages: Record<string, unknown>[]
+    const messageFilter = {
+      locality: SOFIA_LOCALITY,
+      $or: [{ crawledAt: { $gt: sinceDate } }, { finalizedAt: { $gt: sinceDate } }],
+    }
+    try {
+      rawMessages = (await messagesCollection
+        .find(messageFilter)
+        .project({ embedding: 0, process: 0, ingestErrors: 0 })
+        .sort({ finalizedAt: -1, crawledAt: -1 })
+        // Fetch one extra doc so the overflow check works without pulling all matches into memory
+        .limit(limitMax + 1)
+        .toArray()) as Record<string, unknown>[]
+    } catch (err) {
+      req.payload?.logger?.error({ err }, '[updatesExport] Database query failed')
+      return Response.json({ error: 'Failed to query updates database' }, { status: 500 })
+    }
+
+    // ── Overflow guard ────────────────────────────────────────────────────
+    if (rawMessages.length > limitMax) {
+      let messageCount: number
+      try {
+        messageCount = await messagesCollection.countDocuments(messageFilter)
+      } catch (err) {
+        req.payload?.logger?.error({ err }, '[updatesExport] Failed to count documents')
+        return Response.json({ error: 'Failed to query updates database' }, { status: 500 })
+      }
+      return Response.json(
+        {
+          error: 'limitExceeded',
+          messageCount,
+        },
+        { status: 413 }
+      )
+    }
+
+    // ── Map documents ─────────────────────────────────────────────────────
+    const messages: ExportMessage[] = rawMessages
+      .map((doc) => {
+        const msg = docToExportMessage(doc)
+        if (!msg) {
+          req.payload?.logger?.warn(
+            { docId: String(doc._id ?? '') },
+            '[updatesExport] Skipping malformed message document'
+          )
+        }
+        return msg
+      })
+      .filter((m): m is ExportMessage => m !== null)
+
+    return Response.json({
+      since: sinceDate.toISOString(),
+      generatedAt: new Date().toISOString(),
+      messages,
+    })
+  },
+}

--- a/src/endpoints/updatesOpenApi.ts
+++ b/src/endpoints/updatesOpenApi.ts
@@ -30,7 +30,7 @@ const listParameters = [
     name: 'categories',
     in: 'query',
     schema: { type: 'string' },
-    description: 'Comma-separated OboApp category ids',
+    description: 'Comma-separated category ids',
   },
   {
     name: 'timespanEndGte',
@@ -38,6 +38,18 @@ const listParameters = [
     schema: { type: 'string', format: 'date-time' },
     description:
       'ISO timestamp lower bound for message timespan end. Defaults to today start when omitted.',
+  },
+  {
+    name: 'limit',
+    in: 'query',
+    schema: { type: 'integer', minimum: 0, maximum: 500 },
+    description: 'Page size. Defaults to 200 and is capped at 500.',
+  },
+  {
+    name: 'offset',
+    in: 'query',
+    schema: { type: 'integer', minimum: 0 },
+    description: 'Pagination offset. Defaults to 0.',
   },
 ]
 
@@ -48,43 +60,30 @@ export const updatesOpenApi: Endpoint = {
     return Response.json({
       openapi: '3.1.0',
       info: {
-        title: 'Your Sofia API - Updates Proxy',
-        version: '1.0.0',
+        title: 'Your Sofia API - Updates',
+        version: '2.0.0',
       },
       paths: {
         '/api/updates': {
           get: {
-            summary: 'Proxy updates list from upstream public messages API',
+            summary: 'List updates',
             parameters: listParameters,
             responses: {
               '200': {
-                description: 'Updates response proxied from upstream public API',
+                description: 'List of public update messages',
               },
               '400': {
-                description: 'Upstream bad request response (passed through)',
-              },
-              '401': {
-                description: 'Upstream unauthorized response (passed through)',
-              },
-              '403': {
-                description: 'Upstream forbidden response (passed through)',
-              },
-              '404': {
-                description: 'Upstream not found response (passed through)',
+                description: 'Invalid query parameter',
               },
               '500': {
-                description:
-                  'Proxy configuration error (missing/invalid OBOAPP_UPDATES_BASE_URL or missing OBOAPP_API_KEY)',
-              },
-              '502': {
-                description: 'Upstream communication failure or timeout',
+                description: 'Server error',
               },
             },
           },
         },
         '/api/updates/by-id': {
           get: {
-            summary: 'Proxy single update by id from upstream public messages API',
+            summary: 'Fetch a single update by id',
             parameters: [
               {
                 name: 'id',
@@ -95,40 +94,29 @@ export const updatesOpenApi: Endpoint = {
             ],
             responses: {
               '200': {
-                description: 'Single update response proxied from upstream public API',
+                description: 'Single update message',
               },
               '400': {
-                description:
-                  'Missing id parameter or upstream bad request response (passed through)',
-              },
-              '401': {
-                description: 'Upstream unauthorized response (passed through)',
-              },
-              '403': {
-                description: 'Upstream forbidden response (passed through)',
+                description: 'Missing or empty id parameter',
               },
               '404': {
-                description: 'Upstream not found response (passed through)',
+                description: 'Message not found',
               },
               '500': {
-                description:
-                  'Proxy configuration error (missing/invalid OBOAPP_UPDATES_BASE_URL or missing OBOAPP_API_KEY)',
-              },
-              '502': {
-                description: 'Upstream communication failure or timeout',
+                description: 'Server error',
               },
             },
           },
         },
         '/api/updates/sources': {
           get: {
-            summary: 'Proxy update sources metadata from upstream public API',
+            summary: 'List update sources (deprecated — legacy proxy)',
+            deprecated: true,
+            description:
+              'Proxies to the upstream OboApp API. Retained for backwards compatibility with older mobile app versions. Requires OBOAPP_UPDATES_BASE_URL and OBOAPP_API_KEY to be configured.',
             responses: {
               '200': {
-                description: 'Sources metadata response proxied from upstream public API',
-              },
-              '400': {
-                description: 'Upstream bad request response (passed through)',
+                description: 'List of sources from the upstream OboApp API',
               },
               '401': {
                 description: 'Upstream unauthorized response (passed through)',
@@ -139,14 +127,56 @@ export const updatesOpenApi: Endpoint = {
               '404': {
                 description: 'Upstream not found response (passed through)',
               },
-              '500': {
-                description:
-                  'Proxy configuration error (missing/invalid OBOAPP_UPDATES_BASE_URL or missing OBOAPP_API_KEY)',
-              },
               '502': {
                 description: 'Upstream communication failure or timeout',
               },
+              '500': {
+                description: 'Server error or upstream unavailable',
+              },
             },
+          },
+        },
+        '/api/updates-export': {
+          get: {
+            summary: 'Private export endpoint — incremental messages since a given timestamp',
+            description:
+              'Requires X-Api-Key header. Returns messages updated since `since`. Returns 413 if count exceeds the configured limit.',
+            parameters: [
+              {
+                name: 'since',
+                in: 'query',
+                required: true,
+                schema: { type: 'string', format: 'date-time' },
+                description: 'ISO 8601 timestamp — return records updated after this point',
+              },
+            ],
+            security: [{ apiKeyAuth: [] }],
+            responses: {
+              '200': {
+                description: 'Export payload with messages',
+              },
+              '400': {
+                description: 'Missing or invalid since parameter',
+              },
+              '401': {
+                description: 'Missing or invalid X-Api-Key',
+              },
+              '413': {
+                description: 'limitExceeded — message count exceeds configured maximum',
+              },
+              '500': {
+                description: 'Server error (missing config or query failure)',
+              },
+            },
+          },
+        },
+      },
+      components: {
+        securitySchemes: {
+          apiKeyAuth: {
+            type: 'apiKey',
+            in: 'header',
+            name: 'X-Api-Key',
           },
         },
       },

--- a/src/environment.d.ts
+++ b/src/environment.d.ts
@@ -5,8 +5,13 @@ declare global {
       DATABASE_URI: string
       NEXT_PUBLIC_SERVER_URL: string
       VERCEL_PROJECT_PRODUCTION_URL: string
-      OBOAPP_UPDATES_BASE_URL: string
-      OBOAPP_API_KEY: string
+      // YSM OboApp MongoDB — read-only, shared with the YSM OboApp fork ingestion
+      YSM_OBOAPP_MONGODB_URI: string
+      YSM_OBOAPP_MONGODB_DATABASE?: string // default: 'oboapp'
+      // Private key used by oboapp.online to fetch /api/updates-export
+      YSM_OBOAPP_SYNC_API_KEY: string
+      // Maximum combined messages count before /api/updates-export returns 413 (default: '100')
+      YSM_OBOAPP_SYNC_LIMIT_MAX?: string
     }
   }
 }

--- a/src/lib/__tests__/oboMessageMapper.test.ts
+++ b/src/lib/__tests__/oboMessageMapper.test.ts
@@ -1,0 +1,542 @@
+import {
+  docToUpdateMessage,
+  hasNullPinTimespanStart,
+  messageInBounds,
+  sortByRelevance,
+  type UpdateMessage,
+  type ViewportBounds,
+} from '../oboMessageMapper'
+
+// ─── Helpers ──────────────────────────────────────────────────────────────
+
+function makeDoc(overrides: Record<string, unknown> = {}): Record<string, unknown> {
+  return {
+    _id: 'doc-1',
+    text: 'Test update',
+    createdAt: new Date('2026-01-01T00:00:00.000Z'),
+    crawledAt: new Date('2026-01-01T01:00:00.000Z'),
+    finalizedAt: new Date('2026-01-01T02:00:00.000Z'),
+    timespanStart: new Date('2026-01-01T00:00:00.000Z'),
+    timespanEnd: new Date('2026-01-10T00:00:00.000Z'),
+    locality: 'bg.sofia',
+    ...overrides,
+  }
+}
+
+function makeMsg(overrides: Partial<UpdateMessage> = {}): UpdateMessage {
+  return {
+    text: 'Test',
+    createdAt: '2026-01-01T00:00:00.000Z',
+    ...overrides,
+  }
+}
+
+const SOFIA_BOUNDS: ViewportBounds = { north: 42.8, south: 42.6, east: 23.5, west: 23.2 }
+
+// ─── docToUpdateMessage ───────────────────────────────────────────────────
+
+describe('docToUpdateMessage', () => {
+  describe('basic mapping', () => {
+    it('maps a minimal valid doc', () => {
+      const result = docToUpdateMessage({
+        text: 'Hello',
+        createdAt: new Date('2026-01-01T00:00:00.000Z'),
+      })
+      expect(result).not.toBeNull()
+      expect(result!.text).toBe('Hello')
+      expect(result!.createdAt).toBe('2026-01-01T00:00:00.000Z')
+    })
+
+    it('maps a full document correctly', () => {
+      const doc = makeDoc({
+        source: 'sofia-water',
+        sourceUrl: 'https://example.com',
+        locality: 'bg.sofia',
+        markdownText: '**bold**',
+        plainText: 'bold',
+        responsibleEntity: 'Water Dept',
+        cityWide: true,
+        categories: ['water', 'infrastructure'],
+        busStops: ['Stop A', 'Stop B'],
+      })
+      const result = docToUpdateMessage(doc)!
+      expect(result.source).toBe('sofia-water')
+      expect(result.sourceUrl).toBe('https://example.com')
+      expect(result.locality).toBe('bg.sofia')
+      expect(result.markdownText).toBe('**bold**')
+      expect(result.plainText).toBe('bold')
+      expect(result.responsibleEntity).toBe('Water Dept')
+      expect(result.cityWide).toBe(true)
+      expect(result.categories).toEqual(['water', 'infrastructure'])
+      expect(result.busStops).toEqual(['Stop A', 'Stop B'])
+    })
+
+    it('defaults text to empty string when missing', () => {
+      const result = docToUpdateMessage({ createdAt: new Date() })!
+      expect(result.text).toBe('')
+    })
+
+    it('falls back createdAt to now when missing', () => {
+      const before = new Date()
+      const result = docToUpdateMessage({})!
+      const after = new Date()
+      const parsed = new Date(result.createdAt)
+      expect(parsed.getTime()).toBeGreaterThanOrEqual(before.getTime())
+      expect(parsed.getTime()).toBeLessThanOrEqual(after.getTime())
+    })
+
+    it('cityWide is false when not explicitly true', () => {
+      expect(docToUpdateMessage(makeDoc({ cityWide: false }))!.cityWide).toBe(false)
+      expect(docToUpdateMessage(makeDoc({ cityWide: undefined }))!.cityWide).toBe(false)
+      expect(docToUpdateMessage(makeDoc({ cityWide: 'yes' }))!.cityWide).toBe(false)
+    })
+  })
+
+  describe('id handling', () => {
+    it('uses string _id directly', () => {
+      const result = docToUpdateMessage(makeDoc({ _id: 'abc-123' }))!
+      expect(result.id).toBe('abc-123')
+    })
+
+    it('converts object _id via toString', () => {
+      const result = docToUpdateMessage(makeDoc({ _id: { toString: () => 'object-id-value' } }))!
+      expect(result.id).toBe('object-id-value')
+    })
+
+    it('leaves id undefined when _id is missing', () => {
+      const result = docToUpdateMessage(makeDoc({ _id: undefined }))!
+      expect(result.id).toBeUndefined()
+    })
+  })
+
+  describe('date handling', () => {
+    it('converts Date objects to ISO strings', () => {
+      const d = new Date('2026-03-15T12:00:00.000Z')
+      const result = docToUpdateMessage(makeDoc({ crawledAt: d, finalizedAt: d }))!
+      expect(result.crawledAt).toBe('2026-03-15T12:00:00.000Z')
+      expect(result.finalizedAt).toBe('2026-03-15T12:00:00.000Z')
+    })
+
+    it('passes through ISO string dates unchanged', () => {
+      const result = docToUpdateMessage(makeDoc({ crawledAt: '2026-03-15T12:00:00.000Z' }))!
+      expect(result.crawledAt).toBe('2026-03-15T12:00:00.000Z')
+    })
+
+    it('handles Firestore Timestamp shape (toDate method)', () => {
+      const firestoreTs = { toDate: () => new Date('2026-04-01T00:00:00.000Z') }
+      const result = docToUpdateMessage(makeDoc({ crawledAt: firestoreTs }))!
+      expect(result.crawledAt).toBe('2026-04-01T00:00:00.000Z')
+    })
+
+    it('returns undefined for invalid date values', () => {
+      const result = docToUpdateMessage(makeDoc({ crawledAt: 12345 }))!
+      expect(result.crawledAt).toBeUndefined()
+    })
+  })
+
+  describe('timespan fallback rules', () => {
+    it('uses explicit timespanStart and timespanEnd when present', () => {
+      const doc = makeDoc({
+        timespanStart: new Date('2026-02-01T00:00:00.000Z'),
+        timespanEnd: new Date('2026-02-28T00:00:00.000Z'),
+      })
+      const result = docToUpdateMessage(doc)!
+      expect(result.timespanStart).toBe('2026-02-01T00:00:00.000Z')
+      expect(result.timespanEnd).toBe('2026-02-28T00:00:00.000Z')
+    })
+
+    it('mirrors timespanEnd to timespanStart when only end is present', () => {
+      const doc = makeDoc({
+        timespanStart: undefined,
+        timespanEnd: new Date('2026-02-28T00:00:00.000Z'),
+      })
+      const result = docToUpdateMessage(doc)!
+      expect(result.timespanStart).toBe('2026-02-28T00:00:00.000Z')
+      expect(result.timespanEnd).toBe('2026-02-28T00:00:00.000Z')
+    })
+
+    it('mirrors timespanStart to timespanEnd when only start is present', () => {
+      const doc = makeDoc({
+        timespanStart: new Date('2026-02-01T00:00:00.000Z'),
+        timespanEnd: undefined,
+      })
+      const result = docToUpdateMessage(doc)!
+      expect(result.timespanStart).toBe('2026-02-01T00:00:00.000Z')
+      expect(result.timespanEnd).toBe('2026-02-01T00:00:00.000Z')
+    })
+
+    it('falls back to finalizedAt when both timespan fields are absent', () => {
+      const doc = makeDoc({
+        timespanStart: undefined,
+        timespanEnd: undefined,
+        finalizedAt: new Date('2026-01-05T00:00:00.000Z'),
+      })
+      const result = docToUpdateMessage(doc)!
+      expect(result.timespanStart).toBe('2026-01-05T00:00:00.000Z')
+      expect(result.timespanEnd).toBe('2026-01-05T00:00:00.000Z')
+    })
+
+    it('falls back to crawledAt when finalizedAt is also absent', () => {
+      const doc = makeDoc({
+        timespanStart: undefined,
+        timespanEnd: undefined,
+        finalizedAt: undefined,
+        crawledAt: new Date('2026-01-03T00:00:00.000Z'),
+      })
+      const result = docToUpdateMessage(doc)!
+      expect(result.timespanStart).toBe('2026-01-03T00:00:00.000Z')
+      expect(result.timespanEnd).toBe('2026-01-03T00:00:00.000Z')
+    })
+
+    it('falls back to createdAt as last resort', () => {
+      const doc = {
+        createdAt: new Date('2026-01-01T00:00:00.000Z'),
+      }
+      const result = docToUpdateMessage(doc)!
+      expect(result.timespanStart).toBe('2026-01-01T00:00:00.000Z')
+      expect(result.timespanEnd).toBe('2026-01-01T00:00:00.000Z')
+    })
+  })
+
+  describe('geoJson parsing', () => {
+    const validFeatureCollection = {
+      type: 'FeatureCollection',
+      features: [
+        {
+          type: 'Feature',
+          geometry: { type: 'Point', coordinates: [23.32, 42.7] },
+          properties: { name: 'Sofia' },
+        },
+      ],
+    }
+
+    it('accepts an object geoJson directly', () => {
+      const result = docToUpdateMessage(makeDoc({ geoJson: validFeatureCollection }))!
+      expect(result.geoJson).toEqual(validFeatureCollection)
+    })
+
+    it('parses geoJson stored as a stringified JSON string', () => {
+      const result = docToUpdateMessage(
+        makeDoc({ geoJson: JSON.stringify(validFeatureCollection) })
+      )!
+      expect(result.geoJson).toEqual(validFeatureCollection)
+    })
+
+    it('returns undefined geoJson when the string is malformed JSON', () => {
+      const result = docToUpdateMessage(makeDoc({ geoJson: '{invalid json' }))!
+      expect(result.geoJson).toBeUndefined()
+    })
+
+    it('returns undefined geoJson when type is not FeatureCollection', () => {
+      const result = docToUpdateMessage(makeDoc({ geoJson: { type: 'Feature', geometry: {} } }))!
+      expect(result.geoJson).toBeUndefined()
+    })
+
+    it('filters out features with no geometry', () => {
+      const fc = {
+        type: 'FeatureCollection',
+        features: [
+          { type: 'Feature', geometry: null },
+          { type: 'Feature', geometry: { type: 'Point', coordinates: [23.32, 42.7] } },
+        ],
+      }
+      const result = docToUpdateMessage(makeDoc({ geoJson: fc }))!
+      expect(result.geoJson!.features).toHaveLength(1)
+    })
+  })
+
+  describe('pins', () => {
+    it('maps pins with coordinates and timespans', () => {
+      const doc = makeDoc({
+        pins: [
+          {
+            address: 'ul. Vitosha 1',
+            coordinates: { lat: 42.7, lng: 23.32 },
+            timespans: [{ start: '2026-01-01T00:00:00.000Z', end: '2026-01-10T00:00:00.000Z' }],
+          },
+        ],
+      })
+      const result = docToUpdateMessage(doc)!
+      expect(result.pins).toHaveLength(1)
+      expect(result.pins![0].address).toBe('ul. Vitosha 1')
+      expect(result.pins![0].coordinates).toEqual({ lat: 42.7, lng: 23.32 })
+      expect(result.pins![0].timespans[0]).toEqual({
+        start: '2026-01-01T00:00:00.000Z',
+        end: '2026-01-10T00:00:00.000Z',
+      })
+    })
+
+    it('drops pins without an address', () => {
+      const doc = makeDoc({
+        pins: [{ coordinates: { lat: 42.7, lng: 23.32 }, timespans: [] }],
+      })
+      const result = docToUpdateMessage(doc)!
+      expect(result.pins).toHaveLength(0)
+    })
+
+    it('converts Date timespans in pins', () => {
+      const doc = makeDoc({
+        pins: [
+          {
+            address: 'ul. Test 1',
+            timespans: [{ start: new Date('2026-01-01T00:00:00.000Z'), end: null }],
+          },
+        ],
+      })
+      const result = docToUpdateMessage(doc)!
+      expect(result.pins![0].timespans[0].start).toBe('2026-01-01T00:00:00.000Z')
+      expect(result.pins![0].timespans[0].end).toBeNull()
+    })
+  })
+
+  describe('streets', () => {
+    it('maps streets correctly', () => {
+      const doc = makeDoc({
+        streets: [
+          {
+            street: 'ul. Vitosha',
+            from: 'ул. Граф Игнатиев',
+            fromCoordinates: { lat: 42.69, lng: 23.32 },
+            to: 'пл. България',
+            toCoordinates: { lat: 42.7, lng: 23.32 },
+            timespans: [],
+          },
+        ],
+      })
+      const result = docToUpdateMessage(doc)!
+      expect(result.streets).toHaveLength(1)
+      expect(result.streets![0].street).toBe('ul. Vitosha')
+    })
+
+    it('drops streets missing required string fields', () => {
+      const doc = makeDoc({
+        streets: [{ street: 'ul. Test', from: 'A' }], // missing 'to'
+      })
+      const result = docToUpdateMessage(doc)!
+      expect(result.streets).toHaveLength(0)
+    })
+  })
+
+  describe('cadastral properties', () => {
+    it('maps cadastral properties', () => {
+      const doc = makeDoc({
+        cadastralProperties: [
+          { identifier: '68134.407.37', timespans: [{ start: null, end: null }] },
+        ],
+      })
+      const result = docToUpdateMessage(doc)!
+      expect(result.cadastralProperties).toHaveLength(1)
+      expect(result.cadastralProperties![0].identifier).toBe('68134.407.37')
+    })
+
+    it('drops entries without an identifier', () => {
+      const doc = makeDoc({ cadastralProperties: [{ timespans: [] }] })
+      const result = docToUpdateMessage(doc)!
+      expect(result.cadastralProperties).toHaveLength(0)
+    })
+  })
+
+  describe('error resilience', () => {
+    it('returns null when an unrecoverable error is thrown', () => {
+      const circular: Record<string, unknown> = {}
+      Object.defineProperty(circular, 'text', {
+        get() {
+          throw new Error('boom')
+        },
+        enumerable: true,
+      })
+      expect(docToUpdateMessage(circular)).toBeNull()
+    })
+  })
+})
+
+// ─── hasNullPinTimespanStart ──────────────────────────────────────────────
+
+describe('hasNullPinTimespanStart', () => {
+  it('returns false when there are no pins', () => {
+    expect(hasNullPinTimespanStart(makeMsg())).toBe(false)
+  })
+
+  it('returns false when all pin timespans have a start', () => {
+    const msg = makeMsg({
+      pins: [{ address: 'A', timespans: [{ start: '2026-01-01T00:00:00.000Z', end: null }] }],
+    })
+    expect(hasNullPinTimespanStart(msg)).toBe(false)
+  })
+
+  it('returns true when any pin timespan has a null start', () => {
+    const msg = makeMsg({
+      pins: [{ address: 'A', timespans: [{ start: null, end: null }] }],
+    })
+    expect(hasNullPinTimespanStart(msg)).toBe(true)
+  })
+
+  it('returns true when one pin has null start among mixed pins', () => {
+    const msg = makeMsg({
+      pins: [
+        { address: 'A', timespans: [{ start: '2026-01-01T00:00:00.000Z', end: null }] },
+        { address: 'B', timespans: [{ start: null, end: null }] },
+      ],
+    })
+    expect(hasNullPinTimespanStart(msg)).toBe(true)
+  })
+})
+
+// ─── messageInBounds ──────────────────────────────────────────────────────
+
+describe('messageInBounds', () => {
+  it('always returns true for cityWide messages', () => {
+    const msg = makeMsg({ cityWide: true })
+    const outsideBounds: ViewportBounds = { north: 10, south: 9, east: 10, west: 9 }
+    expect(messageInBounds(msg, outsideBounds)).toBe(true)
+  })
+
+  it('returns true when message has no geometry (informational)', () => {
+    expect(messageInBounds(makeMsg(), SOFIA_BOUNDS)).toBe(true)
+  })
+
+  it('returns true for a Point feature inside bounds', () => {
+    const msg = makeMsg({
+      geoJson: {
+        type: 'FeatureCollection',
+        features: [
+          {
+            type: 'Feature',
+            geometry: { type: 'Point', coordinates: [23.32, 42.7] },
+            properties: {},
+          },
+        ],
+      },
+    })
+    expect(messageInBounds(msg, SOFIA_BOUNDS)).toBe(true)
+  })
+
+  it('returns false for a Point feature outside bounds', () => {
+    const msg = makeMsg({
+      geoJson: {
+        type: 'FeatureCollection',
+        features: [
+          {
+            type: 'Feature',
+            geometry: { type: 'Point', coordinates: [24.0, 43.0] },
+            properties: {},
+          },
+        ],
+      },
+    })
+    expect(messageInBounds(msg, SOFIA_BOUNDS)).toBe(false)
+  })
+
+  it('returns true for a LineString whose centroid is inside bounds', () => {
+    const msg = makeMsg({
+      geoJson: {
+        type: 'FeatureCollection',
+        features: [
+          {
+            type: 'Feature',
+            geometry: {
+              type: 'LineString',
+              coordinates: [
+                [23.3, 42.69],
+                [23.34, 42.71],
+              ],
+            },
+          },
+        ],
+      },
+    })
+    expect(messageInBounds(msg, SOFIA_BOUNDS)).toBe(true)
+  })
+
+  it('returns true for a Polygon whose centroid is inside bounds', () => {
+    const msg = makeMsg({
+      geoJson: {
+        type: 'FeatureCollection',
+        features: [
+          {
+            type: 'Feature',
+            geometry: {
+              type: 'Polygon',
+              coordinates: [
+                [
+                  [23.3, 42.69],
+                  [23.34, 42.69],
+                  [23.34, 42.71],
+                  [23.3, 42.71],
+                  [23.3, 42.69],
+                ],
+              ],
+            },
+          },
+        ],
+      },
+    })
+    expect(messageInBounds(msg, SOFIA_BOUNDS)).toBe(true)
+  })
+
+  it('returns true when a pin coordinate is inside bounds', () => {
+    const msg = makeMsg({
+      pins: [{ address: 'A', coordinates: { lat: 42.7, lng: 23.32 }, timespans: [] }],
+    })
+    expect(messageInBounds(msg, SOFIA_BOUNDS)).toBe(true)
+  })
+
+  it('returns false when pin coordinates are outside bounds', () => {
+    const msg = makeMsg({
+      pins: [{ address: 'A', coordinates: { lat: 43.0, lng: 24.0 }, timespans: [] }],
+    })
+    expect(messageInBounds(msg, SOFIA_BOUNDS)).toBe(false)
+  })
+
+  it('returns true when no geometry present even if pins have no coordinates', () => {
+    const msg = makeMsg({
+      pins: [{ address: 'A', timespans: [] }],
+    })
+    expect(messageInBounds(msg, SOFIA_BOUNDS)).toBe(true)
+  })
+})
+
+// ─── sortByRelevance ──────────────────────────────────────────────────────
+
+describe('sortByRelevance', () => {
+  it('sorts by finalizedAt descending', () => {
+    const msgs = [
+      makeMsg({ finalizedAt: '2026-01-01T00:00:00.000Z' }),
+      makeMsg({ finalizedAt: '2026-01-03T00:00:00.000Z' }),
+      makeMsg({ finalizedAt: '2026-01-02T00:00:00.000Z' }),
+    ]
+    const sorted = sortByRelevance(msgs)
+    expect(sorted[0].finalizedAt).toBe('2026-01-03T00:00:00.000Z')
+    expect(sorted[1].finalizedAt).toBe('2026-01-02T00:00:00.000Z')
+    expect(sorted[2].finalizedAt).toBe('2026-01-01T00:00:00.000Z')
+  })
+
+  it('uses timespanEnd as tiebreaker when finalizedAt is equal', () => {
+    const msgs = [
+      makeMsg({ finalizedAt: '2026-01-01T00:00:00.000Z', timespanEnd: '2026-01-05T00:00:00.000Z' }),
+      makeMsg({ finalizedAt: '2026-01-01T00:00:00.000Z', timespanEnd: '2026-01-10T00:00:00.000Z' }),
+    ]
+    const sorted = sortByRelevance(msgs)
+    expect(sorted[0].timespanEnd).toBe('2026-01-10T00:00:00.000Z')
+  })
+
+  it('sorts messages with no finalizedAt last', () => {
+    const msgs = [
+      makeMsg({ finalizedAt: undefined }),
+      makeMsg({ finalizedAt: '2026-01-01T00:00:00.000Z' }),
+    ]
+    const sorted = sortByRelevance(msgs)
+    expect(sorted[0].finalizedAt).toBe('2026-01-01T00:00:00.000Z')
+    expect(sorted[1].finalizedAt).toBeUndefined()
+  })
+
+  it('does not mutate the original array', () => {
+    const msgs = [
+      makeMsg({ finalizedAt: '2026-01-02T00:00:00.000Z' }),
+      makeMsg({ finalizedAt: '2026-01-01T00:00:00.000Z' }),
+    ]
+    const original = [...msgs]
+    sortByRelevance(msgs)
+    expect(msgs).toEqual(original)
+  })
+})

--- a/src/lib/oboMessageMapper.ts
+++ b/src/lib/oboMessageMapper.ts
@@ -336,10 +336,8 @@ function geometryCentroid(geometry: GeoJsonGeometry): Coordinates | null {
     Array.isArray(geometry.coordinates) &&
     geometry.coordinates.length >= 2
   ) {
-    return {
-      lat: (geometry.coordinates as number[])[1],
-      lng: (geometry.coordinates as number[])[0],
-    }
+    const [lng, lat] = geometry.coordinates as [number, number, ...number[]]
+    return { lat, lng }
   }
 
   if (

--- a/src/lib/oboMessageMapper.ts
+++ b/src/lib/oboMessageMapper.ts
@@ -1,0 +1,405 @@
+/**
+ * Maps a raw MongoDB document from the OboApp `messages` collection to the
+ * public UpdateMessage shape consumed by the YSM mobile app.
+ *
+ * Excluded fields (never sent to clients):
+ *   embedding, process, ingestErrors, sourceDocumentId,
+ *   isRelevant, isUnreadable, eventId, notificationsSent
+ *
+ * Dates stored as native MongoDB Date objects are converted to ISO-8601 strings.
+ * Fields stored as stringified JSON (geoJson in some older records) are parsed.
+ */
+
+// ─── Types ────────────────────────────────────────────────────────────────
+
+export interface Coordinates {
+  lat: number
+  lng: number
+}
+
+export interface UpdateAddress {
+  originalText?: string
+  formattedAddress?: string
+  coordinates?: Coordinates
+}
+
+export interface GeoJsonGeometry {
+  type: 'Point' | 'LineString' | 'Polygon' | string
+  coordinates: unknown
+}
+
+export interface GeoJsonFeature {
+  type: 'Feature'
+  geometry: GeoJsonGeometry
+  properties?: Record<string, unknown>
+}
+
+export interface GeoJsonFeatureCollection {
+  type: 'FeatureCollection'
+  features: GeoJsonFeature[]
+}
+
+export interface UpdateTimespan {
+  start: string | null
+  end: string | null
+}
+
+export interface UpdatePin {
+  address: string
+  coordinates?: Coordinates
+  timespans: UpdateTimespan[]
+}
+
+export interface UpdateStreet {
+  street: string
+  from: string
+  fromCoordinates?: Coordinates
+  to: string
+  toCoordinates?: Coordinates
+  timespans: UpdateTimespan[]
+}
+
+export interface UpdateCadastralProperty {
+  identifier: string
+  timespans: UpdateTimespan[]
+}
+
+export interface UpdateMessage {
+  id?: string
+  text: string
+  plainText?: string
+  markdownText?: string
+  addresses?: UpdateAddress[]
+  geoJson?: GeoJsonFeatureCollection
+  createdAt: string
+  crawledAt?: string
+  finalizedAt?: string
+  source?: string
+  sourceUrl?: string
+  categories?: string[]
+  timespanStart?: string
+  timespanEnd?: string
+  cityWide?: boolean
+  responsibleEntity?: string
+  pins?: UpdatePin[]
+  streets?: UpdateStreet[]
+  cadastralProperties?: UpdateCadastralProperty[]
+  busStops?: string[]
+  locality?: string
+}
+
+// ─── Date helpers ─────────────────────────────────────────────────────────
+
+function toISOString(value: unknown): string | undefined {
+  if (!value) return undefined
+  if (value instanceof Date) return value.toISOString()
+  if (typeof value === 'string' && value.length > 0) return value
+  // Firestore Timestamp shape (toDate method)
+  if (typeof value === 'object' && value !== null && 'toDate' in value) {
+    const d = (value as { toDate: () => Date }).toDate()
+    return d instanceof Date ? d.toISOString() : undefined
+  }
+  return undefined
+}
+
+function toRequiredISOString(value: unknown, fallback: string): string {
+  return toISOString(value) ?? fallback
+}
+
+function resolveTimespan(
+  record: Record<string, unknown>,
+  createdAtIso: string
+): { timespanStart: string; timespanEnd: string } {
+  const start = toISOString(record.timespanStart)
+  const end = toISOString(record.timespanEnd)
+  const fallback = toISOString(record.finalizedAt) ?? toISOString(record.crawledAt) ?? createdAtIso
+  return {
+    timespanStart: start ?? end ?? fallback,
+    timespanEnd: end ?? start ?? fallback,
+  }
+}
+
+// ─── Field helpers ────────────────────────────────────────────────────────
+
+function optStr(value: unknown): string | undefined {
+  return typeof value === 'string' ? value : undefined
+}
+
+function toCoordinates(value: unknown): Coordinates | undefined {
+  if (typeof value !== 'object' || value === null) return undefined
+  const c = value as Record<string, unknown>
+  const lat = typeof c.lat === 'number' ? c.lat : undefined
+  const lng = typeof c.lng === 'number' ? c.lng : undefined
+  if (lat === undefined || lng === undefined) return undefined
+  return { lat, lng }
+}
+
+function getAddresses(value: unknown): UpdateAddress[] {
+  if (!Array.isArray(value)) return []
+  return value
+    .map((item: unknown): UpdateAddress | null => {
+      if (typeof item !== 'object' || item === null) return null
+      const a = item as Record<string, unknown>
+      return {
+        originalText: optStr(a.originalText),
+        formattedAddress: optStr(a.formattedAddress),
+        coordinates: toCoordinates(a.coordinates),
+      }
+    })
+    .filter((x): x is UpdateAddress => x !== null)
+}
+
+function parseGeoJsonIfNeeded(value: unknown): unknown {
+  if (typeof value === 'string') {
+    try {
+      return JSON.parse(value)
+    } catch {
+      return undefined
+    }
+  }
+  return value
+}
+
+function getFeatureCollection(value: unknown): GeoJsonFeatureCollection | undefined {
+  const parsed = parseGeoJsonIfNeeded(value)
+  if (typeof parsed !== 'object' || parsed === null) return undefined
+  const fc = parsed as Record<string, unknown>
+  if (fc.type !== 'FeatureCollection' || !Array.isArray(fc.features)) return undefined
+  const features: GeoJsonFeature[] = fc.features
+    .map((f: unknown): GeoJsonFeature | null => {
+      if (typeof f !== 'object' || f === null) return null
+      const feat = f as Record<string, unknown>
+      if (!feat.geometry || typeof feat.geometry !== 'object') return null
+      return {
+        type: 'Feature',
+        geometry: feat.geometry as GeoJsonGeometry,
+        properties:
+          typeof feat.properties === 'object' && feat.properties !== null
+            ? (feat.properties as Record<string, unknown>)
+            : undefined,
+      }
+    })
+    .filter((x): x is GeoJsonFeature => x !== null)
+  return { type: 'FeatureCollection', features }
+}
+
+function getCategories(value: unknown): string[] {
+  if (!Array.isArray(value)) return []
+  return value.filter((v): v is string => typeof v === 'string')
+}
+
+function getTimespans(value: unknown): UpdateTimespan[] {
+  if (!Array.isArray(value)) return []
+  return value
+    .map((item: unknown): UpdateTimespan | null => {
+      if (typeof item !== 'object' || item === null) return null
+      const t = item as Record<string, unknown>
+      const start = toISOString(t.start) ?? null
+      const end = toISOString(t.end) ?? null
+      return { start, end }
+    })
+    .filter((x): x is UpdateTimespan => x !== null)
+}
+
+function getPins(value: unknown): UpdatePin[] {
+  if (!Array.isArray(value)) return []
+  return value
+    .map((item: unknown): UpdatePin | null => {
+      if (typeof item !== 'object' || item === null) return null
+      const p = item as Record<string, unknown>
+      const address = optStr(p.address)
+      if (!address) return null
+      return {
+        address,
+        coordinates: toCoordinates(p.coordinates),
+        timespans: getTimespans(p.timespans),
+      }
+    })
+    .filter((x): x is UpdatePin => x !== null)
+}
+
+function getStreets(value: unknown): UpdateStreet[] {
+  if (!Array.isArray(value)) return []
+  return value
+    .map((item: unknown): UpdateStreet | null => {
+      if (typeof item !== 'object' || item === null) return null
+      const s = item as Record<string, unknown>
+      const street = optStr(s.street)
+      const from = optStr(s.from)
+      const to = optStr(s.to)
+      if (!street || !from || !to) return null
+      return {
+        street,
+        from,
+        fromCoordinates: toCoordinates(s.fromCoordinates),
+        to,
+        toCoordinates: toCoordinates(s.toCoordinates),
+        timespans: getTimespans(s.timespans),
+      }
+    })
+    .filter((x): x is UpdateStreet => x !== null)
+}
+
+function getCadastralProperties(value: unknown): UpdateCadastralProperty[] {
+  if (!Array.isArray(value)) return []
+  return value
+    .map((item: unknown): UpdateCadastralProperty | null => {
+      if (typeof item !== 'object' || item === null) return null
+      const c = item as Record<string, unknown>
+      const identifier = optStr(c.identifier)
+      if (!identifier) return null
+      return { identifier, timespans: getTimespans(c.timespans) }
+    })
+    .filter((x): x is UpdateCadastralProperty => x !== null)
+}
+
+function getBusStops(value: unknown): string[] {
+  if (!Array.isArray(value)) return []
+  return value.filter((v): v is string => typeof v === 'string')
+}
+
+// ─── Public mapper ────────────────────────────────────────────────────────
+
+/**
+ * Convert a raw MongoDB document from the `messages` collection to a public
+ * UpdateMessage.  Returns `null` only when an unrecoverable error occurs;
+ * optional fields such as `createdAt` fall back to safe defaults (e.g. current
+ * time) rather than causing a null return.
+ */
+export function docToUpdateMessage(doc: Record<string, unknown>): UpdateMessage | null {
+  try {
+    const createdAt = toRequiredISOString(doc.createdAt, new Date().toISOString())
+    const { timespanStart, timespanEnd } = resolveTimespan(doc, createdAt)
+
+    const id =
+      typeof doc._id === 'string'
+        ? doc._id
+        : doc._id && typeof (doc._id as Record<string, unknown>).toString === 'function'
+          ? String(doc._id)
+          : undefined
+
+    return {
+      id,
+      text: typeof doc.text === 'string' ? doc.text : '',
+      locality: typeof doc.locality === 'string' ? doc.locality : undefined,
+      plainText: optStr(doc.plainText),
+      markdownText: optStr(doc.markdownText),
+      addresses: getAddresses(doc.addresses),
+      geoJson: getFeatureCollection(doc.geoJson),
+      createdAt,
+      crawledAt: toISOString(doc.crawledAt),
+      finalizedAt: toISOString(doc.finalizedAt),
+      source: optStr(doc.source),
+      sourceUrl: optStr(doc.sourceUrl),
+      categories: getCategories(doc.categories),
+      timespanStart,
+      timespanEnd,
+      cityWide: doc.cityWide === true,
+      responsibleEntity: optStr(doc.responsibleEntity),
+      pins: getPins(doc.pins),
+      streets: getStreets(doc.streets),
+      cadastralProperties: getCadastralProperties(doc.cadastralProperties),
+      busStops: getBusStops(doc.busStops),
+    }
+  } catch {
+    return null
+  }
+}
+
+/**
+ * Returns true if any pin has a null/missing timespans.start.
+ * Messages with such pins are dropped from public responses because they
+ * would display incorrectly on the mobile timeline.
+ */
+export function hasNullPinTimespanStart(msg: UpdateMessage): boolean {
+  return (msg.pins ?? []).some((pin) =>
+    (pin.timespans ?? []).some((ts) => ts.start === null || ts.start === undefined)
+  )
+}
+
+// ─── Viewport helpers ─────────────────────────────────────────────────────
+
+export interface ViewportBounds {
+  north: number
+  south: number
+  east: number
+  west: number
+}
+
+function pointInBounds(lat: number, lng: number, bounds: ViewportBounds): boolean {
+  return lat >= bounds.south && lat <= bounds.north && lng >= bounds.west && lng <= bounds.east
+}
+
+function geometryCentroid(geometry: GeoJsonGeometry): Coordinates | null {
+  if (
+    geometry.type === 'Point' &&
+    Array.isArray(geometry.coordinates) &&
+    geometry.coordinates.length >= 2
+  ) {
+    return {
+      lat: (geometry.coordinates as number[])[1],
+      lng: (geometry.coordinates as number[])[0],
+    }
+  }
+
+  if (
+    (geometry.type === 'LineString' || geometry.type === 'Polygon') &&
+    Array.isArray(geometry.coordinates) &&
+    geometry.coordinates.length > 0
+  ) {
+    const ring: [number, number][] =
+      geometry.type === 'Polygon'
+        ? ((geometry.coordinates as [number, number][][])[0] ?? [])
+        : (geometry.coordinates as [number, number][])
+    if (!ring.length) return null
+    const lats = ring.map((c) => c[1])
+    const lngs = ring.map((c) => c[0])
+    return {
+      lat: (Math.max(...lats) + Math.min(...lats)) / 2,
+      lng: (Math.max(...lngs) + Math.min(...lngs)) / 2,
+    }
+  }
+  return null
+}
+
+/**
+ * Returns true when a message should appear within the given viewport.
+ * cityWide messages are always included when a bounds filter is active.
+ * Messages with no locatable geometry (no geoJson features with coords, no
+ * pins with coordinates) are also always included — they are informational
+ * city-wide messages that cannot be spatially filtered.
+ */
+export function messageInBounds(msg: UpdateMessage, bounds: ViewportBounds): boolean {
+  if (msg.cityWide) return true
+
+  const geoFeatures = msg.geoJson?.features ?? []
+  const pinsWithCoords = (msg.pins ?? []).filter((p) => p.coordinates)
+
+  // No locatable geometry — treat as city-wide informational message
+  if (geoFeatures.length === 0 && pinsWithCoords.length === 0) return true
+
+  for (const feature of geoFeatures) {
+    if (!feature.geometry) continue
+    const centroid = geometryCentroid(feature.geometry)
+    if (centroid && pointInBounds(centroid.lat, centroid.lng, bounds)) return true
+  }
+
+  for (const pin of pinsWithCoords) {
+    if (pointInBounds(pin.coordinates!.lat, pin.coordinates!.lng, bounds)) return true
+  }
+
+  return false
+}
+
+// ─── Sort helper ──────────────────────────────────────────────────────────
+
+export function sortByRelevance(messages: UpdateMessage[]): UpdateMessage[] {
+  return [...messages].sort((a, b) => {
+    const aF = a.finalizedAt ?? ''
+    const bF = b.finalizedAt ?? ''
+    if (aF !== bF) return bF.localeCompare(aF)
+    const aE = a.timespanEnd ?? ''
+    const bE = b.timespanEnd ?? ''
+    return bE.localeCompare(aE)
+  })
+}

--- a/src/lib/oboMongo.ts
+++ b/src/lib/oboMongo.ts
@@ -1,0 +1,66 @@
+/**
+ * Lazy MongoClient singleton for the YSM OboApp MongoDB database.
+ *
+ * ysm-api is a read-only consumer of the same MongoDB instance used by the
+ * YSM OboApp fork's ingestion pipeline.  The connection is created once and
+ * reused across requests.  In development the promise is stored on `global`
+ * so that Next.js hot-reloads don't open a new connection on every module
+ * evaluation.
+ */
+import { MongoClient, type Collection, type Document } from 'mongodb'
+
+// Allow the global to survive Next.js hot-reloads in development.
+declare global {
+  // eslint-disable-next-line no-var
+  var __ysm_obo_mongo_client_promise: Promise<MongoClient> | undefined
+}
+
+let productionClientPromise: Promise<MongoClient> | null = null
+
+export const SOFIA_LOCALITY = 'bg.sofia'
+
+function createClientPromise(): Promise<MongoClient> {
+  const uri = process.env.YSM_OBOAPP_MONGODB_URI
+  if (!uri) {
+    return Promise.reject(new Error('YSM_OBOAPP_MONGODB_URI is not configured'))
+  }
+  const client = new MongoClient(uri)
+  return client.connect()
+}
+
+function getClientPromise(): Promise<MongoClient> {
+  if (process.env.NODE_ENV === 'development') {
+    if (!global.__ysm_obo_mongo_client_promise) {
+      global.__ysm_obo_mongo_client_promise = createClientPromise().catch((err) => {
+        global.__ysm_obo_mongo_client_promise = undefined
+        throw err
+      })
+    }
+    return global.__ysm_obo_mongo_client_promise
+  }
+  if (!productionClientPromise) {
+    productionClientPromise = createClientPromise().catch((err) => {
+      productionClientPromise = null // allow retry on next request
+      throw err
+    })
+  }
+  return productionClientPromise
+}
+
+export function getOboMongoDatabase(): string {
+  return process.env.YSM_OBOAPP_MONGODB_DATABASE ?? 'oboapp'
+}
+
+export async function getMessagesCollection(): Promise<Collection<Document>> {
+  const client = await getClientPromise()
+  return client.db(getOboMongoDatabase()).collection('messages')
+}
+
+export async function getSourcesCollection(): Promise<Collection<Document>> {
+  const client = await getClientPromise()
+  return client.db(getOboMongoDatabase()).collection('sources')
+}
+
+export function isMongoConfigured(): boolean {
+  return Boolean(process.env.YSM_OBOAPP_MONGODB_URI)
+}

--- a/src/payload.config.ts
+++ b/src/payload.config.ts
@@ -35,6 +35,7 @@ import { healthCheck } from './endpoints/health'
 import { updates } from './endpoints/updates'
 import { updatesById } from './endpoints/updatesById'
 import { updatesOpenApi } from './endpoints/updatesOpenApi'
+import { updatesExport } from './endpoints/updatesExport'
 import { updatesSources } from './endpoints/updatesSources'
 import {
   signalsAgeMetric,
@@ -177,6 +178,7 @@ export default buildConfig({
     healthCheck,
     updates,
     updatesById,
+    updatesExport,
     updatesSources,
     updatesOpenApi,
     signalsAgeMetric,

--- a/src/tasks/Notifications/sendUpdatesNotifications.ts
+++ b/src/tasks/Notifications/sendUpdatesNotifications.ts
@@ -1,15 +1,9 @@
 import type { TaskConfig, TaskHandler } from 'payload'
-import { buildUpdatesUpstreamUrl } from '@/endpoints/updatesProxyUtils'
+import type { UpdateMessage } from '@/lib/oboMessageMapper'
+import { docToUpdateMessage } from '@/lib/oboMessageMapper'
+import { getMessagesCollection, isMongoConfigured, SOFIA_LOCALITY } from '@/lib/oboMongo'
 import { matchSubscriptions } from '@/utilities/matchSubscriptions'
 import { sendPushNotifications, sendPushNotificationsToTokens } from '@/utilities/pushNotifications'
-
-interface UpdateMessage {
-  id?: string
-  text: string
-  plainText?: string
-  createdAt: string
-  categories?: string[]
-}
 
 const TASK_SLUG = 'sendUpdatesNotifications'
 
@@ -28,49 +22,31 @@ const handler: TaskHandler<'sendUpdatesNotifications'> = async ({ req }) => {
 
   payload.logger.info(`[${TASK_SLUG}] Checking for updates newer than ${since.toISOString()}`)
 
-  // ── 2. Fetch current active updates from upstream ─────────────────────────
-  const targetUrl = buildUpdatesUpstreamUrl('/messages', {})
-  if (!targetUrl) {
-    payload.logger.error(`[${TASK_SLUG}] OBOAPP_UPDATES_BASE_URL is not configured — skipping`)
+  // ── 2. Fetch new messages from MongoDB ───────────────────────────────────
+  if (!isMongoConfigured()) {
+    payload.logger.error(`[${TASK_SLUG}] MongoDB is not configured — skipping`)
     return { output: { notified: 0 } }
   }
 
-  const apiKey = process.env.OBOAPP_API_KEY
-  if (!apiKey) {
-    payload.logger.error(`[${TASK_SLUG}] OBOAPP_API_KEY is not configured — skipping`)
-    return { output: { notified: 0 } }
-  }
-
-  let messages: UpdateMessage[] = []
+  let newMessages: UpdateMessage[] = []
   try {
-    const res = await fetch(targetUrl.toString(), {
-      headers: { Accept: 'application/json', 'X-Api-Key': apiKey },
-      signal: AbortSignal.timeout(15_000),
-    })
-    if (!res.ok) {
-      payload.logger.error(`[${TASK_SLUG}] Upstream returned ${res.status} — skipping`)
-      return { output: { notified: 0 } }
-    }
-    const body = await res.json()
-    messages = (body.messages ?? []) as UpdateMessage[]
+    const col = await getMessagesCollection()
+    const docs = await col
+      .find(
+        { locality: SOFIA_LOCALITY, finalizedAt: { $gt: since } },
+        { projection: { embedding: 0, process: 0, ingestErrors: 0 } }
+      )
+      .sort({ finalizedAt: 1 })
+      .toArray()
+    newMessages = docs.map(docToUpdateMessage).filter((m): m is UpdateMessage => m !== null)
   } catch (err) {
-    payload.logger.error(`[${TASK_SLUG}] Failed to fetch upstream updates: ${err}`)
+    payload.logger.error(`[${TASK_SLUG}] Failed to query MongoDB for updates: ${err}`)
     return { output: { notified: 0 } }
   }
-
-  // ── 3. Filter to new messages only ────────────────────────────────────────
-  const newMessages = messages.filter((msg) => {
-    if (!msg.createdAt) return false
-    try {
-      return new Date(msg.createdAt) > since
-    } catch {
-      return false
-    }
-  })
 
   payload.logger.info(`[${TASK_SLUG}] ${newMessages.length} new update(s) to notify about`)
 
-  // ── 4. Update global timestamp before sending to avoid double-runs on error ─
+  // ── 3. Update global timestamp before sending to avoid double-runs on error ─
   await payload.updateGlobal({
     slug: 'notification-settings',
     data: { lastUpdatesNotifiedAt: new Date().toISOString() },
@@ -81,7 +57,7 @@ const handler: TaskHandler<'sendUpdatesNotifications'> = async ({ req }) => {
     return { output: { notified: 0 } }
   }
 
-  // ── 5. Send notifications ─────────────────────────────────────────────────
+  // ── 4. Send notifications ─────────────────────────────────────────────────
   let notified = 0
 
   for (const msg of newMessages) {


### PR DESCRIPTION
# Pull Request

## Description

Switch updates loading from api.oboapp.online to a local MongoDB.

## Related Issue

<!-- Link to the issue this PR addresses -->
<!-- Use "Closes #123" or "Fixes #123" to auto-close the issue when merged -->

Closes #

## Changes Made

- Added `GET /api/updates-export` with API-key auth and a configurable maximum result size.
- Refactored `GET /api/updates` and `GET /api/updates/by-id` to query MongoDB directly using shared mapping utilities.
- Updated OpenAPI schema, tests, and environment examples to reflect the new endpoints and configuration.
- Updated sendUpdatesNotifications to also use Mongo.

## Screenshots/Videos (if applicable)

<img width="300" alt="Screenshot_20260522_003503" src="https://github.com/user-attachments/assets/632846ec-7632-4793-8dba-da4e84b11c68" />

## Testing

- Set up an instance of OboApp locally working with MongoDB
- Configure ysm-api (.env) to connect to that same MongoDB
- Run a crawl and ingest in the OboApp instance to populate the `messages` collection in Mongo
- Verify that YSM shows the available messages
