### PR TITLE
10 minutes GPS updates

### DIFF
--- a/src/payload.config.ts
+++ b/src/payload.config.ts
@@ -242,7 +242,7 @@ export default buildConfig({
     tasks: [processWasteCollectionEvents, sendUpdatesNotifications, sendInspectorMetricsReport],
     autoRun: [
       {
-        cron: '*/5 * * * *', // Check every 5 minutes
+        cron: '*/2 * * * *', // Check every 2 minutes
         queue: 'default', // Process 'default' queue (for manually queued jobs)
         limit: 10,
       },

--- a/src/payload.config.ts
+++ b/src/payload.config.ts
@@ -42,7 +42,6 @@ import {
   signalsActiveContainerStateMetric,
 } from './endpoints/signals-metrics'
 import { processWasteCollectionEvents } from './tasks/WasteCollection/processWasteCollectionEvents'
-import { syncWasteCollectionSchedules } from './tasks/WasteCollection/syncWasteCollectionSchedules'
 import { sendUpdatesNotifications } from './tasks/Notifications/sendUpdatesNotifications'
 import { sendInspectorMetricsReport } from './tasks/Reports/sendInspectorMetricsReport'
 import { adminOnly } from '@/access/adminOnly'
@@ -240,12 +239,7 @@ export default buildConfig({
         return authHeader === `Bearer ${process.env.CRON_SECRET}`
       },
     },
-    tasks: [
-      processWasteCollectionEvents,
-      syncWasteCollectionSchedules,
-      sendUpdatesNotifications,
-      sendInspectorMetricsReport,
-    ],
+    tasks: [processWasteCollectionEvents, sendUpdatesNotifications, sendInspectorMetricsReport],
     autoRun: [
       {
         cron: '*/5 * * * *', // Check every 5 minutes

--- a/src/scripts/runWasteCollectionSync.ts
+++ b/src/scripts/runWasteCollectionSync.ts
@@ -23,7 +23,7 @@ function parseArgs(): { from: string; to: string } {
     console.error('Error: --from and --to must both be provided, or neither.')
     process.exit(1)
   }
-  return from && to ? { from, to } : buildSyncWindow(1)
+  return from && to ? { from, to } : buildSyncWindow(12) // Default to last 12 min + 2 min overlap if no input provided
 }
 
 async function main() {

--- a/src/tasks/WasteCollection/gpsCollectionHelpers.ts
+++ b/src/tasks/WasteCollection/gpsCollectionHelpers.ts
@@ -142,12 +142,12 @@ export function formatApiDate(date: Date): string {
   )
 }
 
-/** Compute from/to strings for the given interval sync window ending at `now`. */
+/** Compute from/to strings for the given interval sync window ending at `now` in minutes. */
 export function buildSyncWindow(
-  hoursInterval: number = 1,
+  minutesInterval: number = 10,
   now: Date = new Date()
 ): { from: string; to: string } {
   const to = new Date(now)
-  const from = new Date(now.getTime() - hoursInterval * 60 * 60 * 1000)
+  const from = new Date(now.getTime() - minutesInterval * 60 * 1000)
   return { from: formatApiDate(from), to: formatApiDate(to) }
 }

--- a/src/tasks/WasteCollection/processWasteCollectionEvents.ts
+++ b/src/tasks/WasteCollection/processWasteCollectionEvents.ts
@@ -24,7 +24,7 @@ const handler: TaskHandler<'processWasteCollectionEvents'> = async ({ input, req
   const apiKey = process.env.INSPECTORAT_GPS_API_KEY ?? ''
   const gpsHeaders = { 'X-API-KEY': apiKey }
 
-  const { from, to } = input?.from && input?.to ? input : buildSyncWindow(1)
+  const { from, to } = input?.from && input?.to ? input : buildSyncWindow(12) // Default to last 12 min + 2 min overlap if no input provided
 
   payload.logger.info(`[processWasteCollectionEvents] Starting sync. Window: ${from} → ${to}`)
 
@@ -232,7 +232,7 @@ export const processWasteCollectionEvents: TaskConfig<'processWasteCollectionEve
   slug: 'processWasteCollectionEvents',
   label: 'Process Waste Collection Events',
   schedule: [
-    { cron: '02 * * * *', queue: 'default' }, // Run at 2 minutes past every hour
+    { cron: '*/10 * * * *', queue: 'default' }, // Run every 10 minutes
   ],
   inputSchema: [
     { name: 'from', type: 'text', required: true },


### PR DESCRIPTION
# Pull Request

## Description

Made GPS container collection events be processed each 10 min for prompter updates!

## Related Issue

<!-- Link to the issue this PR addresses -->
<!-- Use "Closes #123" or "Fixes #123" to auto-close the issue when merged -->

Closes #

## Changes Made

<!-- List the main changes in this PR -->

- tasks are processed each 2 min and gps are processed for the window of 10+2 min safety overlap
- - switched off container schedule updates as not needed

