### PR TITLE
Restrict pages access of 'wasteCollector' role

### DIFF
--- a/src/collections/Assignments.ts
+++ b/src/collections/Assignments.ts
@@ -22,6 +22,7 @@ export const Assignments: CollectionConfig = {
     useAsTitle: 'title',
     defaultColumns: ['title', 'status', 'assignedTo', 'dueDate', 'createdAt'],
     group: 'Градска инфраструктура',
+    hidden: ({ user }) => user?.role === 'wasteCollector',
   },
   access: {
     admin: canViewCityInfrastructure,

--- a/src/collections/CityDistricts.ts
+++ b/src/collections/CityDistricts.ts
@@ -13,6 +13,7 @@ export const CityDistricts: CollectionConfig = {
     defaultColumns: ['districtId', 'name', 'wasteCollectionZone'],
     group: 'Градска инфраструктура',
     description: 'Административни райони на София (1–24)',
+    hidden: ({ user }) => user?.role === 'wasteCollector',
   },
   access: {
     admin: canViewCityInfrastructure,

--- a/src/collections/GeocodeAddresses.ts
+++ b/src/collections/GeocodeAddresses.ts
@@ -1,6 +1,6 @@
 import type { CollectionConfig } from 'payload'
 import { locationMapField } from '@/fields/locationMap'
-import { canViewCityInfrastructure } from '@/access/cityInfrastructureAdmin'
+import { cityInfrastructureAdmin } from '@/access/cityInfrastructureAdmin'
 import { isAdmin } from '@/access/isAdmin'
 
 export const GeocodeAddresses: CollectionConfig = {
@@ -15,8 +15,8 @@ export const GeocodeAddresses: CollectionConfig = {
   },
   timestamps: true,
   access: {
-    admin: canViewCityInfrastructure,
-    read: canViewCityInfrastructure,
+    admin: cityInfrastructureAdmin,
+    read: cityInfrastructureAdmin,
     create: isAdmin,
     update: isAdmin,
     delete: isAdmin,

--- a/src/collections/Signals/index.ts
+++ b/src/collections/Signals/index.ts
@@ -48,6 +48,7 @@ export const Signals: CollectionConfig = {
     group: 'Градска инфраструктура',
     description: 'Сигнали от граждани за проблеми',
     listSearchableFields: ['title', 'reporterUniqueId'],
+    hidden: ({ user }) => user?.role === 'wasteCollector',
   },
   defaultSort: '-createdAt',
   hooks: {

--- a/src/collections/Subscriptions.ts
+++ b/src/collections/Subscriptions.ts
@@ -24,6 +24,7 @@ export const Subscriptions: CollectionConfig = {
     defaultColumns: ['pushToken', 'user', 'categories', 'updatedAt'],
     description: 'Push notification subscriptions per device — categories + location filters',
     group: 'Известия',
+    hidden: ({ user }) => user?.role === 'wasteCollector',
   },
   access: {
     create: () => true, // anonymous devices can subscribe

--- a/src/collections/WasteCollectionZones.ts
+++ b/src/collections/WasteCollectionZones.ts
@@ -17,6 +17,7 @@ export const WasteCollectionZones: CollectionConfig = {
     defaultColumns: ['number', 'name', 'serviceCompanyId'],
     group: 'Градска инфраструктура',
     description: 'Карта на зоните за събиране към административните райони и обслужващите фирми',
+    hidden: ({ user }) => user?.role === 'wasteCollector',
   },
   access: {
     admin: canViewCityInfrastructure,

--- a/src/collections/WasteContainerObservations.ts
+++ b/src/collections/WasteContainerObservations.ts
@@ -22,6 +22,7 @@ export const WasteContainerObservations: CollectionConfig = {
     group: 'Градска инфраструктура',
     defaultColumns: ['container', 'cleanedAt', 'vehicleId', 'cleanedBy', 'collectionCount'],
     description: 'Наблюдения при събиране на отпадъци и почистване',
+    hidden: ({ user }) => user?.role === 'wasteCollector',
   },
   fields: [
     {

--- a/src/collections/WasteContainers.ts
+++ b/src/collections/WasteContainers.ts
@@ -27,6 +27,7 @@ export const WasteContainers: CollectionConfig = {
     group: 'Градска инфраструктура',
     description: 'Управление на контейнерите за отпадъци в града',
     listSearchableFields: ['publicNumber', 'legacyId'],
+    hidden: ({ user }) => user?.role === 'wasteCollector',
   },
   endpoints: [
     cleanContainer,

--- a/src/components/WasteContainerMap/NavLink.tsx
+++ b/src/components/WasteContainerMap/NavLink.tsx
@@ -5,14 +5,15 @@ import { useAuth } from '@payloadcms/ui'
 import { usePathname } from 'next/navigation'
 import Link from 'next/link'
 import { MapPin } from 'lucide-react'
-import { isCityInfrastructureAdmin } from '@/access/cityInfrastructureAdmin'
+import { canViewCityInfrastructure } from '@/access/cityInfrastructureAdmin'
+import { PayloadRequest } from 'payload'
 
 const WasteContainerMapNavLink: React.FC = () => {
   const { user } = useAuth()
   const pathname = usePathname()
   const isActive = pathname?.startsWith('/admin/waste-map')
 
-  if (!isCityInfrastructureAdmin(user?.role)) return null
+  if (!canViewCityInfrastructure({ req: { user } } as { req: PayloadRequest })) return null
 
   return (
     <div style={{ padding: '0 8px' }}>

--- a/src/components/WasteContainerMap/index.tsx
+++ b/src/components/WasteContainerMap/index.tsx
@@ -5,7 +5,11 @@ import { useAuth } from '@payloadcms/ui'
 import dynamic from 'next/dynamic'
 import Link from 'next/link'
 import { useSearchParams } from 'next/navigation'
-import { isCityInfrastructureAdmin } from '@/access/cityInfrastructureAdmin'
+import {
+  canViewCityInfrastructure,
+  isCityInfrastructureAdmin,
+} from '@/access/cityInfrastructureAdmin'
+import type { PayloadRequest } from 'payload'
 import { SofiaGerbMark } from '@/components/AdminBrand/SofiaGerbMark'
 import {
   Bounds,
@@ -53,7 +57,8 @@ interface NewPinLocation {
 const WasteContainerMapView: React.FC = () => {
   const { user } = useAuth()
   const searchParams = useSearchParams()
-  const hasAccess = isCityInfrastructureAdmin(user?.role)
+  const hasAccess = canViewCityInfrastructure({ req: { user } } as { req: PayloadRequest })
+  const canAddContainer = isCityInfrastructureAdmin(user?.role)
   const [items, setItems] = useState<MapItem[]>([])
   const [loading, setLoading] = useState(false)
   const [error, setError] = useState<string | null>(null)
@@ -222,12 +227,12 @@ const WasteContainerMapView: React.FC = () => {
 
   const handleMapClick = useCallback(
     (lat: number, lng: number, screenX: number, screenY: number) => {
-      if (!selectMode) {
+      if (!selectMode && canAddContainer) {
         setSelectedContainer(null)
         setNewPin({ lat, lng, screenX, screenY })
       }
     },
-    [selectMode]
+    [selectMode, canAddContainer]
   )
 
   const handleContainerUpdated = useCallback((updated: ContainerWithSignals) => {
@@ -504,7 +509,7 @@ const WasteContainerMapView: React.FC = () => {
         )}
 
         {/* Create pin hint */}
-        {newPin && !selectMode && (
+        {newPin && !selectMode && canAddContainer && (
           <CreatePinHint
             lat={newPin.lat}
             lng={newPin.lng}


### PR DESCRIPTION
Issue #82:
- Restrict the 'wasteCollector' role to have access only to Waste Containers map and Metrics Dashboard;
- Disable map click for creating new containers;